### PR TITLE
Added coercive calls and tests

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -75,9 +75,15 @@ function checkInt32x4(t) {
   * @constructor
   */
 SIMD.float32x4 = function(x, y, z, w) {
+  if (arguments.length == 1) {
+    checkFloat32x4(x);
+    return x;
+  }
+
   if (!(this instanceof SIMD.float32x4)) {
     return new SIMD.float32x4(x, y, z, w);
   }
+
   this.x_ = _PRIVATE.truncatef32(x);
   this.y_ = _PRIVATE.truncatef32(y);
   this.z_ = _PRIVATE.truncatef32(z);
@@ -165,9 +171,15 @@ SIMD.float32x4.fromInt32x4Bits = function(t) {
   * @constructor
   */
 SIMD.float64x2 = function(x, y) {
+  if (arguments.length == 1) {
+    checkFloat64x2(x);
+    return x;
+  }
+
   if (!(this instanceof SIMD.float64x2)) {
     return new SIMD.float64x2(x, y);
   }
+
   this.x_ = x;
   this.y_ = y;
 }
@@ -247,9 +259,15 @@ SIMD.float64x2.fromInt32x4Bits = function(t) {
   * @constructor
   */
 SIMD.int32x4 = function(x, y, z, w) {
+  if (arguments.length == 1) {
+      checkInt32x4(x);
+      return x;
+  }
+
   if (!(this instanceof SIMD.int32x4)) {
     return new SIMD.int32x4(x, y, z, w);
   }
+
   this.x_ = _PRIVATE.truncatei32(x);
   this.y_ = _PRIVATE.truncatei32(y);
   this.z_ = _PRIVATE.truncatei32(z);

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -31,6 +31,23 @@ test('float32x4 constructor', function() {
   notEqual(undefined, SIMD.float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
 });
 
+test('coercive constructors', function() {
+  var x = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+  equal(SIMD.float32x4(x), x);
+  throws(function() {SIMD.float32x4(1)});
+  throws(function() {SIMD.float32x4('hi')});
+
+  var y = SIMD.int32x4(1, 2, 3, 4);
+  equal(SIMD.int32x4(y), y);
+  throws(function() {SIMD.int32x4(1)});
+  throws(function() {SIMD.int32x4('hi')});
+
+  var z = SIMD.float64x2(1.0, 2.0);
+  equal(SIMD.float64x2(z), z);
+  throws(function() {SIMD.float64x2(1)});
+  throws(function() {SIMD.float64x2('hi')});
+});
+
 test('float32x4 fromFloat64x2 constructor', function() {
   var m = SIMD.float64x2(1.0, 2.0);
   var n = SIMD.float32x4.fromFloat64x2(m);


### PR DESCRIPTION
coercive constructor calls have the form: int32x4(x) where x is already an int32x4. More explanation is available in one of the SIMD email threads. Current behavior if the input actually isn't an int32x4 is to throw; logical extensions could be: 
1) if the input x is an object, put x.x in the first lane, x.y in the second lane, etc.
2) put ToInt32(x) in all lanes (which would be equivalent to splat)
