### PR TITLE
Add SIMD types load and store operations

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -32,6 +32,7 @@ _PRIVATE._i32 = new Int32Array(1);
 _PRIVATE._f32x4 = new Float32Array(4);
 _PRIVATE._f64x2 = new Float64Array(_PRIVATE._f32x4.buffer);
 _PRIVATE._i32x4 = new Int32Array(_PRIVATE._f32x4.buffer);
+_PRIVATE._i8x16 = new Int8Array(_PRIVATE._f32x4.buffer);
 
 _PRIVATE._f32x8 = new Float32Array(8);
 _PRIVATE._f64x4 = new Float64Array(4);
@@ -726,6 +727,48 @@ SIMD.float32x4.not = function(a) {
 }
 
 /**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float32x4} New instance of float32x4.
+  */
+SIMD.float32x4.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float32x4(_PRIVATE._f32x4[0], _PRIVATE._f32x4[1],
+                        _PRIVATE._f32x4[2], _PRIVATE._f32x4[3]);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float32x4} value An instance of float32x4.
+  * @return {void}
+  */
+SIMD.float32x4.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat32x4(value);
+  _PRIVATE._f32x4[0] = value.x;
+  _PRIVATE._f32x4[1] = value.y;
+  _PRIVATE._f32x4[2] = value.z;
+  _PRIVATE._f32x4[3] = value.w;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
 * @return {float64x2} New instance of float64x2 with absolute values of
 * t.
 */
@@ -1008,6 +1051,45 @@ SIMD.float64x2.select = function(t, trueValue, falseValue) {
   var tr = SIMD.int32x4.and(t, tv);
   var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
   return SIMD.float64x2.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float64x2} New instance of float64x2.
+  */
+SIMD.float64x2.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float64x2(_PRIVATE._f64x2[0], _PRIVATE._f64x2[1]);
+}
+
+/**
+  * @param {ArrayBuffer} f64a An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float64x2} value An instance of float64x2.
+  * @return {void}
+  */
+SIMD.float64x2.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat64x2(value);
+  _PRIVATE._f64x2[0] = value.x;
+  _PRIVATE._f64x2[1] = value.y;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
 }
 
 /**
@@ -1337,6 +1419,48 @@ SIMD.int32x4.shiftRightArithmetic = function(a, bits) {
   var z = a.z >> bits;
   var w = a.w >> bits;
   return SIMD.int32x4(x, y, z, w);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {int32x4} New instance of int32x4.
+  */
+SIMD.int32x4.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.int32x4(_PRIVATE._i32x4[0], _PRIVATE._i32x4[1],
+                      _PRIVATE._i32x4[2], _PRIVATE._i32x4[3]);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {int32x4} value An instance of int32x4.
+  * @return {void}
+  */
+SIMD.int32x4.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt32x4(value);
+  _PRIVATE._i32x4[0] = value.x;
+  _PRIVATE._i32x4[1] = value.y;
+  _PRIVATE._i32x4[2] = value.z;
+  _PRIVATE._i32x4[3] = value.w;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
 }
 
 Object.defineProperty(SIMD, 'XXXX', { get: function() { return 0x0; } });

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -403,6 +403,67 @@ test('float32x4 float64x2 conversion', function() {
   equal(2.0, n.y);
 });
 
+test('float32x4 load', function() {
+  var a = new Float32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 4; i++) {
+    var v = SIMD.float32x4.load(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(i+3, v.w);
+  }
+});
+
+test('float32x4 store', function() {
+  var a = new Float32Array(10);
+  SIMD.float32x4.store(a.buffer, 0, SIMD.float32x4(0, 1, 2, -1));
+  SIMD.float32x4.store(a.buffer, 12, SIMD.float32x4(3, 4, 5, -1));
+  SIMD.float32x4.store(a.buffer, 24, SIMD.float32x4(6, 7, 8, 9));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float32x4 load exceptions', function () {
+  var a = new Float32Array(8);
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, "a");
+  });
+});
+
+test('float32x4 store exceptions', function () {
+  var a = new Float32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, 28, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, 1, i);
+  });
+});
+
 test('float64x2 constructor', function() {
   equal('function', typeof SIMD.float64x2);
   var m = SIMD.float64x2(1.0, 2.0);
@@ -718,6 +779,65 @@ test('float64x2 select', function() {
   equal(4.0, s.y);
 });
 
+test('float64x2 load', function() {
+  var a = new Float64Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 2; i++) {
+    var v = SIMD.float64x2.load(a.buffer, i * 8);
+    equal(i, v.x);
+    equal(i+1, v.y);
+  }
+});
+
+test('float64x2 store', function() {
+  var a = new Float64Array(6);
+  SIMD.float64x2.store(a.buffer, 0, SIMD.float64x2(0, 1));
+  SIMD.float64x2.store(a.buffer, 16, SIMD.float64x2(2, 3));
+  SIMD.float64x2.store(a.buffer, 32, SIMD.float64x2(4, 5));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float64x2 load exceptions', function () {
+  var a = new Float64Array(8);
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, 112);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, "a");
+  });
+});
+
+test('float64x2 store exceptions', function () {
+  var a = new Float64Array(8);
+  var f = SIMD.float64x2(1, 2);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, 112, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, 1, i);
+  });
+});
+
 test('int32x4 fromFloat32x4 constructor', function() {
   var m = SIMD.float32x4(1.0, 2.2, 3.6, 4.8);
   var n = SIMD.int32x4.fromFloat32x4(m);
@@ -989,6 +1109,67 @@ test('int32x4 select', function() {
   equal(2, s.y);
   equal(7, s.z);
   equal(8, s.w);
+});
+
+test('int32x4 load', function() {
+  var a = new Int32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 4; i++) {
+    var v = SIMD.int32x4.load(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(i+3, v.w);
+  }
+});
+
+test('int32x4 store', function() {
+  var a = new Int32Array(10);
+  SIMD.int32x4.store(a.buffer, 0, SIMD.int32x4(0, 1, 2, -1));
+  SIMD.int32x4.store(a.buffer, 12, SIMD.int32x4(3, 4, 5, -1));
+  SIMD.int32x4.store(a.buffer, 24, SIMD.int32x4(6, 7, 8, 9));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int32x4 load exceptions', function () {
+  var a = new Int32Array(8);
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, "a");
+  });
+});
+
+test('int32x4 store exceptions', function () {
+  var a = new Int32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, -1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, 28, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a, 1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, "a", i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, 1, f);
+  });
 });
 
 test('Float32x4Array simple', function() {


### PR DESCRIPTION
These APIs are used to load and store SIMD types from typed array
wihtout 16-bytes alignment.
