### PR TITLE
Add SIMD types load and store opertaions

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -32,6 +32,7 @@ _PRIVATE._i32 = new Int32Array(1);
 _PRIVATE._f32x4 = new Float32Array(4);
 _PRIVATE._f64x2 = new Float64Array(_PRIVATE._f32x4.buffer);
 _PRIVATE._i32x4 = new Int32Array(_PRIVATE._f32x4.buffer);
+_PRIVATE._i8x16 = new Int8Array(_PRIVATE._f32x4.buffer);
 
 _PRIVATE._f32x8 = new Float32Array(8);
 _PRIVATE._f64x4 = new Float64Array(4);
@@ -726,6 +727,166 @@ SIMD.float32x4.not = function(a) {
 }
 
 /**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float32x4} New instance of float32x4.
+  */
+SIMD.float32x4.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float32x4(_PRIVATE._f32x4[0], _PRIVATE._f32x4[1],
+                        _PRIVATE._f32x4[2], _PRIVATE._f32x4[3]);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float32x4} New instance of float32x4.
+  */
+SIMD.float32x4.loadX = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 4) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 4);
+  for (var i = 0; i < 4; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float32x4(_PRIVATE._f32x4[0], 0.0, 0.0, 0.0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float32x4} New instance of float32x4.
+  */
+SIMD.float32x4.loadXY = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float32x4(_PRIVATE._f32x4[0], _PRIVATE._f32x4[1], 0.0, 0.0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float32x4} New instance of float32x4.
+  */
+SIMD.float32x4.loadXYZ = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 12) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 12);
+  for (var i = 0; i < 12; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float32x4(_PRIVATE._f32x4[0], _PRIVATE._f32x4[1],
+                        _PRIVATE._f32x4[2], 0.0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float32x4} value An instance of float32x4.
+  * @return {void}
+  */
+SIMD.float32x4.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat32x4(value);
+  _PRIVATE._f32x4[0] = value.x;
+  _PRIVATE._f32x4[1] = value.y;
+  _PRIVATE._f32x4[2] = value.z;
+  _PRIVATE._f32x4[3] = value.w;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float32x4} value An instance of float32x4.
+  * @return {void}
+  */
+SIMD.float32x4.storeX = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 4) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat32x4(value);
+  _PRIVATE._f32x4[0] = value.x;
+  var i8a = new Int8Array(buffer, byteOffset, 4);
+  for (var i = 0; i < 4; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float32x4} value An instance of float32x4.
+  * @return {void}
+  */
+SIMD.float32x4.storeXY = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat32x4(value);
+  _PRIVATE._f32x4[0] = value.x;
+  _PRIVATE._f32x4[1] = value.y;
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float32x4} value An instance of float32x4.
+  * @return {void}
+  */
+SIMD.float32x4.storeXYZ = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 12) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat32x4(value);
+  _PRIVATE._f32x4[0] = value.x;
+  _PRIVATE._f32x4[1] = value.y;
+  _PRIVATE._f32x4[2] = value.z;
+  var i8a = new Int8Array(buffer, byteOffset, 12);
+  for (var i = 0; i < 12; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
 * @return {float64x2} New instance of float64x2 with absolute values of
 * t.
 */
@@ -1008,6 +1169,83 @@ SIMD.float64x2.select = function(t, trueValue, falseValue) {
   var tr = SIMD.int32x4.and(t, tv);
   var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
   return SIMD.float64x2.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float64x2} New instance of float64x2.
+  */
+SIMD.float64x2.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float64x2(_PRIVATE._f64x2[0], _PRIVATE._f64x2[1]);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {float64x2} New instance of float64x2.
+  */
+SIMD.float64x2.loadX = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.float64x2(_PRIVATE._f64x2[0], 0.0);
+}
+
+/**
+  * @param {ArrayBuffer} f64a An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float64x2} value An instance of float64x2.
+  * @return {void}
+  */
+SIMD.float64x2.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat64x2(value);
+  _PRIVATE._f64x2[0] = value.x;
+  _PRIVATE._f64x2[1] = value.y;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} f64a An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {float64x2} value An instance of float64x2.
+  * @return {void}
+  */
+SIMD.float64x2.storeX = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkFloat64x2(value);
+  _PRIVATE._f64x2[0] = value.x;
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
 }
 
 /**
@@ -1337,6 +1575,166 @@ SIMD.int32x4.shiftRightArithmetic = function(a, bits) {
   var z = a.z >> bits;
   var w = a.w >> bits;
   return SIMD.int32x4(x, y, z, w);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {int32x4} New instance of int32x4.
+  */
+SIMD.int32x4.load = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.int32x4(_PRIVATE._i32x4[0], _PRIVATE._i32x4[1],
+                      _PRIVATE._i32x4[2], _PRIVATE._i32x4[3]);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {int32x4} New instance of int32x4.
+  */
+SIMD.int32x4.loadX = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 4) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 4);
+  for (var i = 0; i < 4; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.int32x4(_PRIVATE._i32x4[0], 0, 0, 0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {int32x4} New instance of int32x4.
+  */
+SIMD.int32x4.loadXY = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.int32x4(_PRIVATE._i32x4[0], _PRIVATE._i32x4[1], 0, 0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @return {int32x4} New instance of int32x4.
+  */
+SIMD.int32x4.loadXYZ = function(buffer, byteOffset) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 12) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  var i8a = new Int8Array(buffer, byteOffset, 12);
+  for (var i = 0; i < 12; i++)
+    _PRIVATE._i8x16[i] = i8a[i];
+  return SIMD.int32x4(_PRIVATE._i32x4[0], _PRIVATE._i32x4[1],
+                      _PRIVATE._i32x4[2], 0);
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {int32x4} value An instance of int32x4.
+  * @return {void}
+  */
+SIMD.int32x4.store = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 16) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt32x4(value);
+  _PRIVATE._i32x4[0] = value.x;
+  _PRIVATE._i32x4[1] = value.y;
+  _PRIVATE._i32x4[2] = value.z;
+  _PRIVATE._i32x4[3] = value.w;
+  var i8a = new Int8Array(buffer, byteOffset, 16);
+  for (var i = 0; i < 16; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {int32x4} value An instance of int32x4.
+  * @return {void}
+  */
+SIMD.int32x4.storeX = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 4) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt32x4(value);
+  _PRIVATE._i32x4[0] = value.x;
+  var i8a = new Int8Array(buffer, byteOffset, 4);
+  for (var i = 0; i < 4; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {int32x4} value An instance of int32x4.
+  * @return {void}
+  */
+SIMD.int32x4.storeXY = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 8) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt32x4(value);
+  _PRIVATE._i32x4[0] = value.x;
+  _PRIVATE._i32x4[1] = value.y;
+  var i8a = new Int8Array(buffer, byteOffset, 8);
+  for (var i = 0; i < 8; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
+}
+
+/**
+  * @param {ArrayBuffer} buffer An instance of ArrayBuffer.
+  * @param {Number} byteOffset An instance of Number.
+  * @param {int32x4} value An instance of int32x4.
+  * @return {void}
+  */
+SIMD.int32x4.storeXYZ = function(buffer, byteOffset, value) {
+  if (!isArrayBuffer(buffer))
+    throw new TypeError("The 1st argument must be an ArrayBuffer.");
+  if (!isNumber(byteOffset))
+    throw new TypeError("The 2nd argument must be a Number.");
+  if (byteOffset < 0 || (byteOffset + 12) > buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt32x4(value);
+  _PRIVATE._i32x4[0] = value.x;
+  _PRIVATE._i32x4[1] = value.y;
+  _PRIVATE._i32x4[2] = value.z;
+  var i8a = new Int8Array(buffer, byteOffset, 12);
+  for (var i = 0; i < 12; i++)
+    i8a[i] = _PRIVATE._i8x16[i];
 }
 
 Object.defineProperty(SIMD, 'XXXX', { get: function() { return 0x0; } });

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -407,6 +407,252 @@ test('float32x4 float64x2 conversion', function() {
   equal(2.0, n.y);
 });
 
+test('float32x4 load', function() {
+  var a = new Float32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 3; i++) {
+    var v = SIMD.float32x4.load(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(i+3, v.w);
+  }
+});
+
+test('float32x4 loadX', function() {
+  var a = new Float32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length; i++) {
+    var v = SIMD.float32x4.loadX(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(0.0, v.y);
+    equal(0.0, v.z);
+    equal(0.0, v.w);
+  }
+});
+
+test('float32x4 loadXY', function() {
+  var a = new Float32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 1; i++) {
+    var v = SIMD.float32x4.loadXY(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(0.0, v.z);
+    equal(0.0, v.w);
+  }
+});
+
+test('float32x4 loadXYZ', function() {
+  var a = new Float32Array(9);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 2; i++) {
+    var v = SIMD.float32x4.loadXYZ(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(0.0, v.w);
+  }
+});
+
+test('float32x4 store', function() {
+  var a = new Float32Array(12);
+  SIMD.float32x4.store(a.buffer, 0, SIMD.float32x4(0, 1, 2, 3));
+  SIMD.float32x4.store(a.buffer, 16, SIMD.float32x4(4, 5, 6, 7));
+  SIMD.float32x4.store(a.buffer, 32, SIMD.float32x4(8, 9, 10, 11));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float32x4 storeX', function() {
+  var a = new Float32Array(4);
+  SIMD.float32x4.storeX(a.buffer, 0, SIMD.float32x4(0, -1, -1, -1));
+  SIMD.float32x4.storeX(a.buffer, 4, SIMD.float32x4(1, -1, -1, -1));
+  SIMD.float32x4.storeX(a.buffer, 8, SIMD.float32x4(2, -1, -1, -1));
+  SIMD.float32x4.storeX(a.buffer, 12, SIMD.float32x4(3, -1, -1, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float32x4 storeXY', function() {
+  var a = new Float32Array(8);
+  SIMD.float32x4.storeXY(a.buffer, 0, SIMD.float32x4(0, 1, -1, -1));
+  SIMD.float32x4.storeXY(a.buffer, 8, SIMD.float32x4(2, 3, -1, -1));
+  SIMD.float32x4.storeXY(a.buffer, 16, SIMD.float32x4(4, 5, -1, -1));
+  SIMD.float32x4.storeXY(a.buffer, 24, SIMD.float32x4(6, 7, -1, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float32x4 storeXYZ', function() {
+  var a = new Float32Array(9);
+  SIMD.float32x4.storeXYZ(a.buffer, 0, SIMD.float32x4(0, 1, 2, -1));
+  SIMD.float32x4.storeXYZ(a.buffer, 12, SIMD.float32x4(3, 4, 5, -1));
+  SIMD.float32x4.storeXYZ(a.buffer, 24, SIMD.float32x4(6, 7, 8, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float32x4 load exceptions', function () {
+  var a = new Float32Array(8);
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.load(a.buffer, "a");
+  });
+});
+
+test('float32x4 loadX exceptions', function () {
+  var a = new Float32Array(8);
+  throws(function () {
+    var f = SIMD.float32x4.loadX(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadX(a.buffer, 30);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadX(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadX(a.buffer, "a");
+  });
+});
+
+test('float32x4 loadXY exceptions', function () {
+  var a = new Float32Array(8);
+  throws(function () {
+    var f = SIMD.float32x4.loadXY(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXY(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXY(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXY(a.buffer, "a");
+  });
+});
+
+test('float32x4 loadXYZ exceptions', function () {
+  var a = new Float32Array(8);
+  throws(function () {
+    var f = SIMD.float32x4.loadXYZ(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXYZ(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXYZ(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float32x4.loadXYZ(a.buffer, "a");
+  });
+});
+
+test('float32x4 store exceptions', function () {
+  var a = new Float32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, 28, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float32x4.store(a.buffer, 1, i);
+  });
+});
+
+test('float32x4 storeX exceptions', function () {
+  var a = new Float32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float32x4.storeX(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeX(a.buffer, 30, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeX(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeX(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeX(a.buffer, 1, i);
+  });
+});
+
+test('float32x4 storeXY exceptions', function () {
+  var a = new Float32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float32x4.storeXY(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXY(a.buffer, 28, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXY(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXY(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXY(a.buffer, 1, i);
+  });
+});
+
+test('float32x4 storeXYZ exceptions', function () {
+  var a = new Float32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float32x4.storeXYZ(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXYZ(a.buffer, 28, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXYZ(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXYZ(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float32x4.storeXYZ(a.buffer, 1, i);
+  });
+});
+
 test('float64x2 constructor', function() {
   equal('function', typeof SIMD.float64x2);
   var m = SIMD.float64x2(1.0, 2.0);
@@ -726,6 +972,125 @@ test('float64x2 select', function() {
   equal(4.0, s.y);
 });
 
+test('float64x2 load', function() {
+  var a = new Float64Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 1; i++) {
+    var v = SIMD.float64x2.load(a.buffer, i * 8);
+    equal(i, v.x);
+    equal(i+1, v.y);
+  }
+});
+
+test('float64x2 loadX', function() {
+  var a = new Float64Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length; i++) {
+    var v = SIMD.float64x2.loadX(a.buffer, i * 8);
+    equal(i, v.x);
+    equal(0.0, v.y);
+  }
+});
+
+test('float64x2 store', function() {
+  var a = new Float64Array(6);
+  SIMD.float64x2.store(a.buffer, 0, SIMD.float64x2(0, 1));
+  SIMD.float64x2.store(a.buffer, 16, SIMD.float64x2(2, 3));
+  SIMD.float64x2.store(a.buffer, 32, SIMD.float64x2(4, 5));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float64x2 storeX', function() {
+  var a = new Float64Array(4);
+  SIMD.float64x2.storeX(a.buffer, 0, SIMD.float64x2(0, -1));
+  SIMD.float64x2.storeX(a.buffer, 8, SIMD.float64x2(1, -1));
+  SIMD.float64x2.storeX(a.buffer, 16, SIMD.float64x2(2, -1));
+  SIMD.float64x2.storeX(a.buffer, 24, SIMD.float64x2(3, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('float64x2 load exceptions', function () {
+  var a = new Float64Array(8);
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, 50);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.load(a.buffer, "a");
+  });
+});
+
+test('float64x2 loadX exceptions', function () {
+  var a = new Float64Array(8);
+  throws(function () {
+    var f = SIMD.float64x2.loadX(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.loadX(a.buffer, 60);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.loadX(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.float64x2.loadX(a.buffer, "a");
+  });
+});
+
+test('float64x2 store exceptions', function () {
+  var a = new Float64Array(8);
+  var f = SIMD.float64x2(1, 2);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, 50, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float64x2.store(a.buffer, 1, i);
+  });
+});
+
+test('float64x2 storeX exceptions', function () {
+  var a = new Float64Array(8);
+  var f = SIMD.float64x2(1, 2);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.float64x2.storeX(a.buffer, -1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.storeX(a.buffer, 60, f);
+  });
+  throws(function () {
+    SIMD.float64x2.storeX(a, 1, f);
+  });
+  throws(function () {
+    SIMD.float64x2.storeX(a.buffer, "a", f);
+  });
+  throws(function () {
+    SIMD.float64x2.storeX(a.buffer, 1, i);
+  });
+});
+
 test('int32x4 fromFloat32x4 constructor', function() {
   var m = SIMD.float32x4(1.0, 2.2, 3.6, 4.8);
   var n = SIMD.int32x4.fromFloat32x4(m);
@@ -997,6 +1362,252 @@ test('int32x4 select', function() {
   equal(2, s.y);
   equal(7, s.z);
   equal(8, s.w);
+});
+
+test('int32x4 load', function() {
+  var a = new Int32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 3; i++) {
+    var v = SIMD.int32x4.load(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(i+3, v.w);
+  }
+});
+
+test('int32x4 loadX', function() {
+  var a = new Int32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length ; i++) {
+    var v = SIMD.int32x4.loadX(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(0, v.y);
+    equal(0, v.z);
+    equal(0, v.w);
+  }
+});
+
+test('int32x4 loadXY', function() {
+  var a = new Int32Array(8);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 1; i++) {
+    var v = SIMD.int32x4.loadXY(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(0, v.z);
+    equal(0, v.w);
+  }
+});
+
+test('int32x4 loadXYZ', function() {
+  var a = new Int32Array(9);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 2; i++) {
+    var v = SIMD.int32x4.loadXYZ(a.buffer, i * 4);
+    equal(i, v.x);
+    equal(i+1, v.y);
+    equal(i+2, v.z);
+    equal(0, v.w);
+  }
+});
+
+test('int32x4 store', function() {
+  var a = new Int32Array(12);
+  SIMD.int32x4.store(a.buffer, 0, SIMD.int32x4(0, 1, 2, 3));
+  SIMD.int32x4.store(a.buffer, 16, SIMD.int32x4(4, 5, 6, 7));
+  SIMD.int32x4.store(a.buffer, 32, SIMD.int32x4(8, 9, 10, 11));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int32x4 storeX', function() {
+  var a = new Int32Array(4);
+  SIMD.int32x4.storeX(a.buffer, 0, SIMD.int32x4(0, -1, -1, -1));
+  SIMD.int32x4.storeX(a.buffer, 4, SIMD.int32x4(1, -1, -1, -1));
+  SIMD.int32x4.storeX(a.buffer, 8, SIMD.int32x4(2, -1, -1, -1));
+  SIMD.int32x4.storeX(a.buffer, 12, SIMD.int32x4(3, -1, -1, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int32x4 storeXY', function() {
+  var a = new Int32Array(8);
+  SIMD.int32x4.storeXY(a.buffer, 0, SIMD.int32x4(0, 1, -1, -1));
+  SIMD.int32x4.storeXY(a.buffer, 8, SIMD.int32x4(2, 3, -1, -1));
+  SIMD.int32x4.storeXY(a.buffer, 16, SIMD.int32x4(4, 5, -1, -1));
+  SIMD.int32x4.storeXY(a.buffer, 24, SIMD.int32x4(6, 7, -1, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int32x4 storeXYZ', function() {
+  var a = new Int32Array(9);
+  SIMD.int32x4.storeXYZ(a.buffer, 0, SIMD.int32x4(0, 1, 2, -1));
+  SIMD.int32x4.storeXYZ(a.buffer, 12, SIMD.int32x4(3, 4, 5, -1));
+  SIMD.int32x4.storeXYZ(a.buffer, 24, SIMD.int32x4(6, 7, 8, -1));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int32x4 load exceptions', function () {
+  var a = new Int32Array(8);
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.load(a.buffer, "a");
+  });
+});
+
+test('int32x4 loadX exceptions', function () {
+  var a = new Int32Array(8);
+  throws(function () {
+    var f = SIMD.int32x4.loadX(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadX(a.buffer, 30);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadX(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadX(a.buffer, "a");
+  });
+});
+
+test('int32x4 loadXY exceptions', function () {
+  var a = new Int32Array(8);
+  throws(function () {
+    var f = SIMD.int32x4.loadXY(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXY(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXY(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXY(a.buffer, "a");
+  });
+});
+
+test('int32x4 loadXYZ exceptions', function () {
+  var a = new Int32Array(8);
+  throws(function () {
+    var f = SIMD.int32x4.loadXYZ(a.buffer, -1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXYZ(a.buffer, 28);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXYZ(a, 1);
+  });
+  throws(function () {
+    var f = SIMD.int32x4.loadXYZ(a.buffer, "a");
+  });
+});
+
+test('int32x4 store exceptions', function () {
+  var a = new Int32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, -1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, 28, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a, 1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, "a", i);
+  });
+  throws(function () {
+    SIMD.int32x4.store(a.buffer, 1, f);
+  });
+});
+
+test('int32x4 storeX exceptions', function () {
+  var a = new Int32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int32x4.storeX(a.buffer, -1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeX(a.buffer, 30, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeX(a, 1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeX(a.buffer, "a", i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeX(a.buffer, 1, f);
+  });
+});
+
+test('int32x4 storeXY exceptions', function () {
+  var a = new Int32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int32x4.storeXY(a.buffer, -1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXY(a.buffer, 28, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXY(a, 1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXY(a.buffer, "a", i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXY(a.buffer, 1, f);
+  });
+});
+
+test('int32x4 storeXYZ exceptions', function () {
+  var a = new Int32Array(8);
+  var f = SIMD.float32x4(1, 2, 3, 4);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int32x4.storeXYZ(a.buffer, -1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXYZ(a.buffer, 28, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXYZ(a, 1, i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXYZ(a.buffer, "a", i);
+  });
+  throws(function () {
+    SIMD.int32x4.storeXYZ(a.buffer, 1, f);
+  });
 });
 
 test('Float32x4Array simple', function() {


### PR DESCRIPTION
They are useful to load/store vec1, vec2, vec3 or vec4 into/from
SIMD types from/into ArrayBuffer with byte offset.

The new APIs include:
- SIMD.float32x4.load
- SIMD.float32x4.loadX
- SIMD.float32x4.loadXY
- SIMD.float32x4.loadXYZ
- SIMD.float32x4.store
- SIMD.float32x4.storeXY
- SIMD.float32x4.storeXYZ
- SIMD.float64x2.load
- SIMD.float64x2.loadX
- SIMD.float64x2.store
- SIMD.float64x2.storeX
- SIMD.int32x4.load
- SIMD.int32x4.loadX
- SIMD.int32x4.loadXY
- SIMD.int32x4.loadXYZ
- SIMD.int32x4.store
- SIMD.int32x4.storeX
- SIMD.int32x4.storeXY
- SIMD.int32x4.storeXYZ
