### PR TITLE
Remove "use strict" from the polyfill.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -18,8 +18,6 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-"use strict";
-
 // SIMD module.
 var SIMD = {};
 

--- a/src/float32x4array.js
+++ b/src/float32x4array.js
@@ -18,8 +18,6 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-"use strict";
-
 function Float32x4Array(a, b, c) {
   function isNumber(o) {
       return typeof o == "number" || (typeof o == "object" && o.constructor === Number);

--- a/src/int32x4array.js
+++ b/src/int32x4array.js
@@ -18,9 +18,6 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-"use strict";
-
-
 function Int32x4Array(a, b, c) {
 
   function isNumber(o) {


### PR DESCRIPTION
Applications may wish to use the SIMD polyfill without having
"use strict" applied to themselves.
