### PR TITLE
Implement new min/max semantics

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1029,8 +1029,8 @@ SIMD.float64x2.max = function(t, other) {
 SIMD.float64x2.minNum = function(t, other) {
   checkFloat64x2(t);
   checkFloat64x2(other);
-  var cx = _PRIVATE.minNum(t.x > other.x);
-  var cy = _PRIVATE.minNum(t.y > other.y);
+  var cx = _PRIVATE.minNum(t.x, other.x);
+  var cy = _PRIVATE.minNum(t.y, other.y);
   return SIMD.float64x2(cx, cy);
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -234,6 +234,26 @@ test('float32x4 min', function() {
   notEqual(z.w, z.w);
 });
 
+test('float32x4 minNum', function() {
+  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
+  var c = SIMD.float32x4.minNum(a, lower);
+  equal(-20.0, c.x);
+  equal(1.0, c.y);
+  equal(30.0, c.z);
+  equal(0.0, c.w);
+
+  var x = SIMD.float32x4(-0, 0, NaN, 0);
+  var y = SIMD.float32x4(0, -0, 0, NaN);
+  var z = SIMD.float32x4.minNum(x, y);
+  equal(0, z.x);
+  equal(1 / z.x, -Infinity);
+  equal(0, z.y);
+  equal(1 / z.y, -Infinity);
+  equal(0, z.z);
+  equal(0, z.w);
+});
+
 test('float32x4 min exceptions', function() {
   var ok    = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
   var notOk = 1;
@@ -263,6 +283,26 @@ test('float32x4 max', function() {
   equal(1 / z.y, Infinity);
   notEqual(z.z, z.z);
   notEqual(z.w, z.w);
+});
+
+test('float32x4 maxNum', function() {
+  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
+  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
+  var c = SIMD.float32x4.maxNum(a, upper);
+  equal(2.5, c.x);
+  equal(10.0, c.y);
+  equal(55.0, c.z);
+  equal(1.0, c.w);
+
+  var x = SIMD.float32x4(-0, 0, NaN, 0);
+  var y = SIMD.float32x4(0, -0, 0, NaN);
+  var z = SIMD.float32x4.maxNum(x, y);
+  equal(0, z.x);
+  equal(1 / z.x, Infinity);
+  equal(0, z.y);
+  equal(1 / z.y, Infinity);
+  equal(0, z.z);
+  equal(0, z.w);
 });
 
 test('float32x4 max exceptions', function() {
@@ -878,6 +918,27 @@ test('float64x2 min', function() {
   notEqual(z.y, z.y);
 });
 
+test('float64x2 minNum', function() {
+  var a = SIMD.float64x2(-20.0, 10.0);
+  var lower = SIMD.float64x2(2.0, 1.0);
+  var c = SIMD.float64x2.minNum(a, lower);
+  equal(-20.0, c.x);
+  equal(1.0, c.y);
+
+  var x = SIMD.float64x2(-0, 0);
+  var y = SIMD.float64x2(0, -0);
+  var z = SIMD.float64x2.minNum(x, y);
+  equal(0, z.x);
+  equal(1 / z.x, -Infinity);
+  equal(0, z.y);
+  equal(1 / z.y, -Infinity);
+  x = SIMD.float64x2(NaN, 0);
+  y = SIMD.float64x2(0, NaN);
+  z = SIMD.float64x2.minNum(x, y);
+  equal(0, z.x);
+  equal(0, z.y);
+});
+
 test('float64x2 min exceptions', function() {
   var ok    = SIMD.float64x2(1.0, 2.0);
   var notOk = 1;
@@ -908,6 +969,27 @@ test('float64x2 max', function() {
   z = SIMD.float64x2.max(x, y);
   notEqual(z.x, z.x);
   notEqual(z.y, z.y);
+});
+
+test('float64x2 maxNum', function() {
+  var a = SIMD.float64x2(-20.0, 10.0);
+  var upper = SIMD.float64x2(2.5, 5.0);
+  var c = SIMD.float64x2.maxNum(a, upper);
+  equal(2.5, c.x);
+  equal(10.0, c.y);
+
+  var x = SIMD.float64x2(-0, 0);
+  var y = SIMD.float64x2(0, -0);
+  var z = SIMD.float64x2.maxNum(x, y);
+  equal(0, z.x);
+  equal(1 / z.x, Infinity);
+  equal(0, z.y);
+  equal(1 / z.y, Infinity);
+  x = SIMD.float64x2(NaN, 0);
+  y = SIMD.float64x2(0, NaN);
+  z = SIMD.float64x2.maxNum(x, y);
+  equal(0, z.x);
+  equal(0, z.y);
 });
 
 test('float64x2 max exceptions', function() {


### PR DESCRIPTION
Following the proposal in
https://github.com/johnmccutchan/ecmascript_simd/issues/67

These min and max functions follow the Math.min and Math.max semantics,
and are arguably the more intuitive and semantics.

This patch also introduces minNum and maxNum functions, which follow the
IEEE-754 minNum and maxNum semantics.
