### PR TITLE
Int16x8 and Int8x16 support

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -27,11 +27,14 @@ var _PRIVATE = {}
 _PRIVATE._f32x4 = new Float32Array(4);
 _PRIVATE._f64x2 = new Float64Array(_PRIVATE._f32x4.buffer);
 _PRIVATE._i32x4 = new Int32Array(_PRIVATE._f32x4.buffer);
+_PRIVATE._i16x8 = new Int16Array(_PRIVATE._f32x4.buffer);
 _PRIVATE._i8x16 = new Int8Array(_PRIVATE._f32x4.buffer);
 
 _PRIVATE._f32x8 = new Float32Array(8);
 _PRIVATE._f64x4 = new Float64Array(4);
 _PRIVATE._i32x8 = new Int32Array(8);
+_PRIVATE._i16x16 = new Int16Array(16);
+_PRIVATE._i8x32 = new Int8Array(32);
 
 if (typeof Math.fround != 'undefined') {
   _PRIVATE.truncatef32 = Math.fround;
@@ -80,6 +83,103 @@ function checkInt32x4(t) {
   if (!(t instanceof SIMD.int32x4)) {
     throw new TypeError("argument is not a int32x4.");
   }
+}
+
+function checkInt16x8(t) {
+  if (!(t instanceof SIMD.int16x8)) {
+    throw new TypeError("argument is not a int16x8.");
+  }
+}
+
+function checkInt8x16(t) {
+  if (!(t instanceof SIMD.int8x16)) {
+    throw new TypeError("argument is not a int8x16.");
+  }
+}
+
+// Save/Restore utilities for implementing bitwise conversions.
+
+_PRIVATE.saveFloat64x2 = function(x) {
+  checkFloat64x2(x);
+  _PRIVATE._f64x2[0] = x.x_;
+  _PRIVATE._f64x2[1] = x.y_;
+}
+
+_PRIVATE.saveFloat32x4 = function(x) {
+  checkFloat32x4(x);
+  _PRIVATE._f32x4[0] = x.x_;
+  _PRIVATE._f32x4[1] = x.y_;
+  _PRIVATE._f32x4[2] = x.z_;
+  _PRIVATE._f32x4[3] = x.w_;
+}
+
+_PRIVATE.saveInt32x4 = function(x) {
+  checkInt32x4(x);
+  _PRIVATE._i32x4[0] = x.x_;
+  _PRIVATE._i32x4[1] = x.y_;
+  _PRIVATE._i32x4[2] = x.z_;
+  _PRIVATE._i32x4[3] = x.w_;
+}
+
+_PRIVATE.saveInt16x8 = function(x) {
+  checkInt16x8(x);
+  _PRIVATE._i16x8[0] = x.s0_;
+  _PRIVATE._i16x8[1] = x.s1_;
+  _PRIVATE._i16x8[2] = x.s2_;
+  _PRIVATE._i16x8[3] = x.s3_;
+  _PRIVATE._i16x8[4] = x.s4_;
+  _PRIVATE._i16x8[5] = x.s5_;
+  _PRIVATE._i16x8[6] = x.s6_;
+  _PRIVATE._i16x8[7] = x.s7_;
+}
+
+_PRIVATE.saveInt8x16 = function(x) {
+  checkInt8x16(x);
+  _PRIVATE._i8x16[0] = x.s0_;
+  _PRIVATE._i8x16[1] = x.s1_;
+  _PRIVATE._i8x16[2] = x.s2_;
+  _PRIVATE._i8x16[3] = x.s3_;
+  _PRIVATE._i8x16[4] = x.s4_;
+  _PRIVATE._i8x16[5] = x.s5_;
+  _PRIVATE._i8x16[6] = x.s6_;
+  _PRIVATE._i8x16[7] = x.s7_;
+  _PRIVATE._i8x16[8] = x.s8_;
+  _PRIVATE._i8x16[9] = x.s9_;
+  _PRIVATE._i8x16[10] = x.s10_;
+  _PRIVATE._i8x16[11] = x.s11_;
+  _PRIVATE._i8x16[12] = x.s12_;
+  _PRIVATE._i8x16[13] = x.s13_;
+  _PRIVATE._i8x16[14] = x.s14_;
+  _PRIVATE._i8x16[15] = x.s15_;
+}
+
+_PRIVATE.restoreFloat64x2 = function() {
+  var alias = _PRIVATE._f64x2;
+  return SIMD.float64x2(alias[0], alias[1]);
+}
+
+_PRIVATE.restoreFloat32x4 = function() {
+  var alias = _PRIVATE._f32x4;
+  return SIMD.float32x4(alias[0], alias[1], alias[2], alias[3]);
+}
+
+_PRIVATE.restoreInt32x4 = function() {
+  var alias = _PRIVATE._i32x4;
+  return SIMD.int32x4(alias[0], alias[1], alias[2], alias[3]);
+}
+
+_PRIVATE.restoreInt16x8 = function() {
+  var alias = _PRIVATE._i16x8;
+  return SIMD.int16x8(alias[0], alias[1], alias[2], alias[3],
+                      alias[4], alias[5], alias[6], alias[7]);
+}
+
+_PRIVATE.restoreInt8x16 = function() {
+  var alias = _PRIVATE._i8x16;
+  return SIMD.int8x16(alias[0], alias[1], alias[2], alias[3],
+                      alias[4], alias[5], alias[6], alias[7],
+                      alias[8], alias[9], alias[10], alias[11],
+                      alias[12], alias[13], alias[14], alias[15]);
 }
 
 /**
@@ -139,13 +239,8 @@ SIMD.float32x4.fromInt32x4 = function(t) {
  * @return {float32x4} a bit-wise copy of t as a float32x4.
  */
 SIMD.float32x4.fromFloat64x2Bits = function(t) {
-  checkFloat64x2(t);
-  _PRIVATE._f64x2[0] = t.x_;
-  _PRIVATE._f64x2[1] = t.y_;
-  return SIMD.float32x4(_PRIVATE._f32x4[0],
-                        _PRIVATE._f32x4[1],
-                        _PRIVATE._f32x4[2],
-                        _PRIVATE._f32x4[3]);
+  _PRIVATE.saveFloat64x2(t);
+  return _PRIVATE.restoreFloat32x4();
 }
 
 /**
@@ -153,15 +248,26 @@ SIMD.float32x4.fromFloat64x2Bits = function(t) {
  * @return {float32x4} a bit-wise copy of t as a float32x4.
  */
 SIMD.float32x4.fromInt32x4Bits = function(t) {
-  checkInt32x4(t);
-  _PRIVATE._i32x4[0] = t.x_;
-  _PRIVATE._i32x4[1] = t.y_;
-  _PRIVATE._i32x4[2] = t.z_;
-  _PRIVATE._i32x4[3] = t.w_;
-  return SIMD.float32x4(_PRIVATE._f32x4[0],
-                        _PRIVATE._f32x4[1],
-                        _PRIVATE._f32x4[2],
-                        _PRIVATE._f32x4[3]);
+  _PRIVATE.saveInt32x4(t);
+  return _PRIVATE.restoreFloat32x4();
+}
+
+/**
+ * @param {int16x8} t An instance of int16x8.
+ * @return {float32x4} a bit-wise copy of t as a float32x4.
+ */
+SIMD.float32x4.fromInt16x8Bits = function(t) {
+  _PRIVATE.saveInt16x8(t);
+  return _PRIVATE.restoreFloat32x4();
+}
+
+/**
+ * @param {int8x16} t An instance of int8x16.
+ * @return {float32x4} a bit-wise copy of t as a float32x4.
+ */
+SIMD.float32x4.fromInt8x16Bits = function(t) {
+  _PRIVATE.saveInt8x16(t);
+  return _PRIVATE.restoreFloat32x4();
 }
 
 /**
@@ -218,12 +324,8 @@ SIMD.float64x2.fromInt32x4 = function(t) {
  * @return {float64x2} a bit-wise copy of t as a float64x2.
  */
 SIMD.float64x2.fromFloat32x4Bits = function(t) {
-  checkFloat32x4(t);
-  _PRIVATE._f32x4[0] = t.x_;
-  _PRIVATE._f32x4[1] = t.y_;
-  _PRIVATE._f32x4[2] = t.z_;
-  _PRIVATE._f32x4[3] = t.w_;
-  return SIMD.float64x2(_PRIVATE._f64x2[0], _PRIVATE._f64x2[1]);
+  _PRIVATE.saveFloat32x4(t);
+  return _PRIVATE.restoreFloat64x2();
 }
 
 /**
@@ -231,12 +333,26 @@ SIMD.float64x2.fromFloat32x4Bits = function(t) {
  * @return {float64x2} a bit-wise copy of t as a float64x2.
  */
 SIMD.float64x2.fromInt32x4Bits = function(t) {
-  checkInt32x4(t);
-  _PRIVATE._i32x4[0] = t.x_;
-  _PRIVATE._i32x4[1] = t.y_;
-  _PRIVATE._i32x4[2] = t.z_;
-  _PRIVATE._i32x4[3] = t.w_;
-  return SIMD.float64x2(_PRIVATE._f64x2[0], _PRIVATE._f64x2[1]);
+  _PRIVATE.saveInt32x4(t);
+  return _PRIVATE.restoreFloat64x2();
+}
+
+/**
+ * @param {int16x8} t An instance of int16x8.
+ * @return {float64x2} a bit-wise copy of t as a float64x2.
+ */
+SIMD.float64x2.fromInt16x8Bits = function(t) {
+  _PRIVATE.saveInt16x8(t);
+  return _PRIVATE.restoreFloat64x2();
+}
+
+/**
+ * @param {int8x16} t An instance of int8x16.
+ * @return {float64x2} a bit-wise copy of t as a float64x2.
+ */
+SIMD.float64x2.fromInt8x16Bits = function(t) {
+  _PRIVATE.saveInt8x16(t);
+  return _PRIVATE.restoreFloat64x2();
 }
 
 /**
@@ -312,13 +428,8 @@ SIMD.int32x4.fromFloat64x2 = function(t) {
   * @return {int32x4} a bit-wise copy of t as a int32x4.
   */
 SIMD.int32x4.fromFloat32x4Bits = function(t) {
-  checkFloat32x4(t);
-  _PRIVATE._f32x4[0] = t.x_;
-  _PRIVATE._f32x4[1] = t.y_;
-  _PRIVATE._f32x4[2] = t.z_;
-  _PRIVATE._f32x4[3] = t.w_;
-  var alias = _PRIVATE._i32x4;
-  return SIMD.int32x4(alias[0], alias[1], alias[2], alias[3]);
+  _PRIVATE.saveFloat32x4(t);
+  return _PRIVATE.restoreInt32x4();
 }
 
 /**
@@ -326,11 +437,267 @@ SIMD.int32x4.fromFloat32x4Bits = function(t) {
  * @return {int32x4} a bit-wise copy of t as an int32x4.
  */
 SIMD.int32x4.fromFloat64x2Bits = function(t) {
-  checkFloat64x2(t);
-  _PRIVATE._f64x2[0] = t.x_;
-  _PRIVATE._f64x2[1] = t.y_;
-  var alias = _PRIVATE._i32x4;
-  return SIMD.int32x4(alias[0], alias[1], alias[2], alias[3]);
+  _PRIVATE.saveFloat64x2(t);
+  return _PRIVATE.restoreInt32x4();
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @return {int32x4} a bit-wise copy of t as a int32x4.
+  */
+SIMD.int32x4.fromInt16x8Bits = function(t) {
+  _PRIVATE.saveInt16x8(t);
+  return _PRIVATE.restoreInt32x4();
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @return {int32x4} a bit-wise copy of t as a int32x4.
+  */
+SIMD.int32x4.fromInt8x16Bits = function(t) {
+  _PRIVATE.saveInt8x16(t);
+  return _PRIVATE.restoreInt32x4();
+}
+
+/**
+  * Construct a new instance of int16x8 number.
+  * @param {integer} 16-bit value used for s0 lane.
+  * @param {integer} 16-bit value used for s1 lane.
+  * @param {integer} 16-bit value used for s2 lane.
+  * @param {integer} 16-bit value used for s3 lane.
+  * @param {integer} 16-bit value used for s4 lane.
+  * @param {integer} 16-bit value used for s5 lane.
+  * @param {integer} 16-bit value used for s6 lane.
+  * @param {integer} 16-bit value used for s7 lane.
+  * @constructor
+  */
+SIMD.int16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+  if (arguments.length == 1) {
+    checkInt16x8(s0);
+    return s0;
+  }
+
+  if (!(this instanceof SIMD.int16x8)) {
+    return new SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+  }
+
+  this.s0_ = s0 << 16 >> 16;
+  this.s1_ = s1 << 16 >> 16;
+  this.s2_ = s2 << 16 >> 16;
+  this.s3_ = s3 << 16 >> 16;
+  this.s4_ = s4 << 16 >> 16;
+  this.s5_ = s5 << 16 >> 16;
+  this.s6_ = s6 << 16 >> 16;
+  this.s7_ = s7 << 16 >> 16;
+}
+
+/**
+  * Construct a new instance of int16x8 number with 0xFFFF or 0x0 in each
+  * lane, depending on the truth value in s0, s1, s2, s3, s4, s5, s6, and s7.
+  * @param {boolean} flag used for s0 lane.
+  * @param {boolean} flag used for s1 lane.
+  * @param {boolean} flag used for s2 lane.
+  * @param {boolean} flag used for s3 lane.
+  * @param {boolean} flag used for s4 lane.
+  * @param {boolean} flag used for s5 lane.
+  * @param {boolean} flag used for s6 lane.
+  * @param {boolean} flag used for s7 lane.
+  * @constructor
+  */
+SIMD.int16x8.bool = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+  return SIMD.int16x8(s0 ? -1 : 0x0,
+                      s1 ? -1 : 0x0,
+                      s2 ? -1 : 0x0,
+                      s3 ? -1 : 0x0,
+                      s4 ? -1 : 0x0,
+                      s5 ? -1 : 0x0,
+                      s6 ? -1 : 0x0,
+                      s7 ? -1 : 0x0);
+}
+
+/**
+  * Construct a new instance of int16x8 number with the same value
+  * in all lanes.
+  * @param {integer} value used for all lanes.
+  * @constructor
+  */
+SIMD.int16x8.splat = function(s) {
+  return SIMD.int16x8(s, s, s, s, s, s, s, s);
+}
+
+/**
+  * @param {float32x4} t An instance of float32x4.
+  * @return {int16x8} a bit-wise copy of t as a int16x8.
+  */
+SIMD.int16x8.fromFloat32x4Bits = function(t) {
+  _PRIVATE.saveFloat32x4(t);
+  return _PRIVATE.restoreInt16x8();
+}
+
+/**
+ * @param {float64x2} t An instance of float64x2.
+ * @return {int16x8} a bit-wise copy of t as an int16x8.
+ */
+SIMD.int16x8.fromFloat64x2Bits = function(t) {
+  _PRIVATE.saveFloat64x2(t);
+  return _PRIVATE.restoreInt16x8();
+}
+
+/**
+  * @param {int32x4} t An instance of int32x4.
+  * @return {int16x8} a bit-wise copy of t as a int16x8.
+  */
+SIMD.int16x8.fromInt32x4Bits = function(t) {
+  _PRIVATE.saveInt32x4(t);
+  return _PRIVATE.restoreInt16x8();
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @return {int16x8} a bit-wise copy of t as a int16x8.
+  */
+SIMD.int16x8.fromInt8x16Bits = function(t) {
+  _PRIVATE.saveInt8x16(t);
+  return _PRIVATE.restoreInt16x8();
+}
+
+/**
+  * Construct a new instance of int8x16 number.
+  * @param {integer} 8-bit value used for s0 lane.
+  * @param {integer} 8-bit value used for s1 lane.
+  * @param {integer} 8-bit value used for s2 lane.
+  * @param {integer} 8-bit value used for s3 lane.
+  * @param {integer} 8-bit value used for s4 lane.
+  * @param {integer} 8-bit value used for s5 lane.
+  * @param {integer} 8-bit value used for s6 lane.
+  * @param {integer} 8-bit value used for s7 lane.
+  * @param {integer} 8-bit value used for s8 lane.
+  * @param {integer} 8-bit value used for s9 lane.
+  * @param {integer} 8-bit value used for s10 lane.
+  * @param {integer} 8-bit value used for s11 lane.
+  * @param {integer} 8-bit value used for s12 lane.
+  * @param {integer} 8-bit value used for s13 lane.
+  * @param {integer} 8-bit value used for s14 lane.
+  * @param {integer} 8-bit value used for s15 lane.
+  * @constructor
+  */
+SIMD.int8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
+                        s8, s9, s10, s11, s12, s13, s14, s15) {
+  if (arguments.length == 1) {
+    checkInt8x16(s0);
+    return s0;
+  }
+
+  if (!(this instanceof SIMD.int8x16)) {
+    return new SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                            s8, s9, s10, s11, s12, s13, s14, s15);
+  }
+
+  this.s0_ = s0 << 24 >> 24;
+  this.s1_ = s1 << 24 >> 24;
+  this.s2_ = s2 << 24 >> 24;
+  this.s3_ = s3 << 24 >> 24;
+  this.s4_ = s4 << 24 >> 24;
+  this.s5_ = s5 << 24 >> 24;
+  this.s6_ = s6 << 24 >> 24;
+  this.s7_ = s7 << 24 >> 24;
+  this.s8_ = s8 << 24 >> 24;
+  this.s9_ = s9 << 24 >> 24;
+  this.s10_ = s10 << 24 >> 24;
+  this.s11_ = s11 << 24 >> 24;
+  this.s12_ = s12 << 24 >> 24;
+  this.s13_ = s13 << 24 >> 24;
+  this.s14_ = s14 << 24 >> 24;
+  this.s15_ = s15 << 24 >> 24;
+}
+
+/**
+  * Construct a new instance of int8x16 number with 0xFF or 0x0 in each
+  * lane, depending on the truth value in s0, s1, s2, s3, s4, s5, s6, s7,
+  * s8, s9, s10, s11, s12, s13, s14, and s15.
+  * @param {boolean} flag used for s0 lane.
+  * @param {boolean} flag used for s1 lane.
+  * @param {boolean} flag used for s2 lane.
+  * @param {boolean} flag used for s3 lane.
+  * @param {boolean} flag used for s4 lane.
+  * @param {boolean} flag used for s5 lane.
+  * @param {boolean} flag used for s6 lane.
+  * @param {boolean} flag used for s7 lane.
+  * @param {boolean} flag used for s8 lane.
+  * @param {boolean} flag used for s9 lane.
+  * @param {boolean} flag used for s10 lane.
+  * @param {boolean} flag used for s11 lane.
+  * @param {boolean} flag used for s12 lane.
+  * @param {boolean} flag used for s13 lane.
+  * @param {boolean} flag used for s14 lane.
+  * @param {boolean} flag used for s15 lane.
+  * @constructor
+  */
+SIMD.int8x16.bool = function(s0, s1, s2, s3, s4, s5, s6, s7,
+                             s8, s9, s10, s11, s12, s13, s14, s15) {
+  return SIMD.int8x16(s0 ? -1 : 0x0,
+                      s1 ? -1 : 0x0,
+                      s2 ? -1 : 0x0,
+                      s3 ? -1 : 0x0,
+                      s4 ? -1 : 0x0,
+                      s5 ? -1 : 0x0,
+                      s6 ? -1 : 0x0,
+                      s7 ? -1 : 0x0,
+                      s8 ? -1 : 0x0,
+                      s9 ? -1 : 0x0,
+                      s10 ? -1 : 0x0,
+                      s11 ? -1 : 0x0,
+                      s12 ? -1 : 0x0,
+                      s13 ? -1 : 0x0,
+                      s14 ? -1 : 0x0,
+                      s15 ? -1 : 0x0);
+}
+
+/**
+  * Construct a new instance of int8x16 number with the same value
+  * in all lanes.
+  * @param {integer} value used for all lanes.
+  * @constructor
+  */
+SIMD.int8x16.splat = function(s) {
+  return SIMD.int8x16(s, s, s, s, s, s, s, s,
+                      s, s, s, s, s, s, s, s);
+}
+
+/**
+  * @param {float32x4} t An instance of float32x4.
+  * @return {int8x16} a bit-wise copy of t as a int8x16.
+  */
+SIMD.int8x16.fromFloat32x4Bits = function(t) {
+  _PRIVATE.saveFloat32x4(t);
+  return _PRIVATE.restoreInt8x16();
+}
+
+/**
+ * @param {float64x2} t An instance of float64x2.
+ * @return {int8x16} a bit-wise copy of t as an int8x16.
+ */
+SIMD.int8x16.fromFloat64x2Bits = function(t) {
+  _PRIVATE.saveFloat64x2(t);
+  return _PRIVATE.restoreInt8x16();
+}
+
+/**
+  * @param {int32x4} t An instance of int32x4.
+  * @return {int8x16} a bit-wise copy of t as a int8x16.
+  */
+SIMD.int8x16.fromInt32x4Bits = function(t) {
+  _PRIVATE.saveInt32x4(t);
+  return _PRIVATE.restoreInt8x16();
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @return {int8x16} a bit-wise copy of t as a int8x16.
+  */
+SIMD.int8x16.fromInt16x8Bits = function(t) {
+  _PRIVATE.saveInt16x8(t);
+  return _PRIVATE.restoreInt8x16();
 }
 
 /**
@@ -1899,6 +2266,654 @@ SIMD.int32x4.storeXYZ = function(tarray, index, value) {
   }
 }
 
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a & b.
+  */
+SIMD.int16x8.and = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(a.s0 & b.s0, a.s1 & b.s1, a.s2 & b.s2, a.s3 & b.s3,
+                      a.s4 & b.s4, a.s5 & b.s5, a.s6 & b.s6, a.s7 & b.s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a | b.
+  */
+SIMD.int16x8.or = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(a.s0 | b.s0, a.s1 | b.s1, a.s2 | b.s2, a.s3 | b.s3,
+                      a.s4 | b.s4, a.s5 | b.s5, a.s6 | b.s6, a.s7 | b.s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a ^ b.
+  */
+SIMD.int16x8.xor = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(a.s0 ^ b.s0, a.s1 ^ b.s1, a.s2 ^ b.s2, a.s3 ^ b.s3,
+                      a.s4 ^ b.s4, a.s5 ^ b.s5, a.s6 ^ b.s6, a.s7 ^ b.s7);
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of ~t
+  */
+SIMD.int16x8.not = function(t) {
+  checkInt16x8(t);
+  return SIMD.int16x8(~t.s0, ~t.s1, ~t.s2, ~t.s3,
+                      ~t.s4, ~t.s5, ~t.s6, ~t.s7);
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of -t
+  */
+SIMD.int16x8.neg = function(t) {
+  checkInt16x8(t);
+  return SIMD.int16x8(-t.s0, -t.s1, -t.s2, -t.s3,
+                      -t.s4, -t.s5, -t.s6, -t.s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a + b.
+  */
+SIMD.int16x8.add = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(a.s0 + b.s0, a.s1 + b.s1, a.s2 + b.s2, a.s3 + b.s3,
+                      a.s4 + b.s4, a.s5 + b.s5, a.s6 + b.s6, a.s7 + b.s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a - b.
+  */
+SIMD.int16x8.sub = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(a.s0 - b.s0, a.s1 - b.s1, a.s2 - b.s2, a.s3 - b.s3,
+                      a.s4 - b.s4, a.s5 - b.s5, a.s6 - b.s6, a.s7 - b.s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int16x8} b An instance of int16x8.
+  * @return {int16x8} New instance of int16x8 with values of a * b.
+  */
+SIMD.int16x8.mul = function(a, b) {
+  checkInt16x8(a);
+  checkInt16x8(b);
+  return SIMD.int16x8(Math.imul(a.s0, b.s0), Math.imul(a.s1, b.s1),
+                      Math.imul(a.s2, b.s2), Math.imul(a.s3, b.s3),
+                      Math.imul(a.s4, b.s4), Math.imul(a.s5, b.s5),
+                      Math.imul(a.s6, b.s6), Math.imul(a.s7, b.s7));
+}
+
+/**
+  * @param {int16x8} t Selector mask. An instance of int16x8
+  * @param {int16x8} trueValue Pick lane from here if corresponding
+  * selector lane is 0xFFFF
+  * @param {int16x8} falseValue Pick lane from here if corresponding
+  * selector lane is 0x0
+  * @return {int16x8} Mix of lanes from trueValue or falseValue as
+  * indicated
+  */
+SIMD.int16x8.select = function(t, trueValue, falseValue) {
+  checkInt16x8(t);
+  checkInt16x8(trueValue);
+  checkInt16x8(falseValue);
+  var tr = SIMD.int16x8.and(t, trueValue);
+  var fr = SIMD.int16x8.and(SIMD.int16x8.not(t), falseValue);
+  return SIMD.int16x8.or(tr, fr);
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @param {int16x8} other An instance of int16x8.
+  * @return {int16x8} 0xFFFF or 0x0 in each lane depending on
+  * the result of t == other.
+  */
+SIMD.int16x8.equal = function(t, other) {
+  checkInt16x8(t);
+  checkInt16x8(other);
+  var cs0 = t.s0 == other.s0;
+  var cs1 = t.s1 == other.s1;
+  var cs2 = t.s2 == other.s2;
+  var cs3 = t.s3 == other.s3;
+  var cs4 = t.s4 == other.s4;
+  var cs5 = t.s5 == other.s5;
+  var cs6 = t.s6 == other.s6;
+  var cs7 = t.s7 == other.s7;
+  return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @param {int16x8} other An instance of int16x8.
+  * @return {int16x8} 0xFFFF or 0x0 in each lane depending on
+  * the result of t > other.
+  */
+SIMD.int16x8.greaterThan = function(t, other) {
+  checkInt16x8(t);
+  checkInt16x8(other);
+  var cs0 = t.s0 > other.s0;
+  var cs1 = t.s1 > other.s1;
+  var cs2 = t.s2 > other.s2;
+  var cs3 = t.s3 > other.s3;
+  var cs4 = t.s4 > other.s4;
+  var cs5 = t.s5 > other.s5;
+  var cs6 = t.s6 > other.s6;
+  var cs7 = t.s7 > other.s7;
+  return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+}
+
+/**
+  * @param {int16x8} t An instance of int16x8.
+  * @param {int16x8} other An instance of int16x8.
+  * @return {int16x8} 0xFFFF or 0x0 in each lane depending on
+  * the result of t < other.
+  */
+SIMD.int16x8.lessThan = function(t, other) {
+  checkInt16x8(t);
+  checkInt16x8(other);
+  var cs0 = t.s0 < other.s0;
+  var cs1 = t.s1 < other.s1;
+  var cs2 = t.s2 < other.s2;
+  var cs3 = t.s3 < other.s3;
+  var cs4 = t.s4 < other.s4;
+  var cs5 = t.s5 < other.s5;
+  var cs6 = t.s6 < other.s6;
+  var cs7 = t.s7 < other.s7;
+  return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int} bits Bit count to shift by.
+  * @return {int16x8} lanes in a shifted by bits.
+  */
+SIMD.int16x8.shiftLeftByScalar = function(a, bits) {
+  checkInt16x8(a);
+  var s0 = a.s0 << bits;
+  var s1 = a.s1 << bits;
+  var s2 = a.s2 << bits;
+  var s3 = a.s3 << bits;
+  var s4 = a.s4 << bits;
+  var s5 = a.s5 << bits;
+  var s6 = a.s6 << bits;
+  var s7 = a.s7 << bits;
+  return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int} bits Bit count to shift by.
+  * @return {int16x8} lanes in a shifted by bits.
+  */
+SIMD.int16x8.shiftRightLogicalByScalar = function(a, bits) {
+  checkInt16x8(a);
+  var s0 = (a.s0 & 0xffff) >>> bits;
+  var s1 = (a.s1 & 0xffff) >>> bits;
+  var s2 = (a.s2 & 0xffff) >>> bits;
+  var s3 = (a.s3 & 0xffff) >>> bits;
+  var s4 = (a.s4 & 0xffff) >>> bits;
+  var s5 = (a.s5 & 0xffff) >>> bits;
+  var s6 = (a.s6 & 0xffff) >>> bits;
+  var s7 = (a.s7 & 0xffff) >>> bits;
+  return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+}
+
+/**
+  * @param {int16x8} a An instance of int16x8.
+  * @param {int} bits Bit count to shift by.
+  * @return {int16x8} lanes in a shifted by bits.
+  */
+SIMD.int16x8.shiftRightArithmeticByScalar = function(a, bits) {
+  checkInt16x8(a);
+  var s0 = a.s0 >> bits;
+  var s1 = a.s1 >> bits;
+  var s2 = a.s2 >> bits;
+  var s3 = a.s3 >> bits;
+  var s4 = a.s4 >> bits;
+  var s5 = a.s5 >> bits;
+  var s6 = a.s6 >> bits;
+  var s7 = a.s7 >> bits;
+  return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+}
+
+/**
+  * @param {Typed array} tarray An instance of a typed array.
+  * @param {Number} index An instance of Number.
+  * @return {int16x8} New instance of int16x8.
+  */
+SIMD.int16x8.load = function(tarray, index) {
+  if (!isTypedArray(tarray))
+    throw new TypeError("The 1st argument must be a typed array.");
+  if (!_PRIVATE.isNumber(index))
+    throw new TypeError("The 2nd argument must be a Number.");
+  var bpe = tarray.BYTES_PER_ELEMENT;
+  if (index < 0 || (index * bpe + 16) > tarray.byteLength)
+    throw new RangeError("The value of index is invalid.");
+  var i16temp = _PRIVATE._i16x8;
+  var array = bpe == 1 ? _PRIVATE._i8x16 :
+              bpe == 2 ? i16temp :
+              bpe == 4 ? (tarray instanceof Float32Array ? _PRIVATE._f32x4 : _PRIVATE._i32x4) :
+              _PRIVATE._f64x2;
+  var n = 16 / bpe;
+  for (var i = 0; i < n; ++i)
+    array[i] = tarray[index + i];
+  return new SIMD.int16x8(i16temp[0], i16temp[1], i16temp[2], i16temp[3],
+                          i16temp[4], i16temp[5], i16temp[6], i16temp[7]);
+}
+
+/**
+  * @param {Typed array} tarray An instance of a typed array.
+  * @param {Number} index An instance of Number.
+  * @param {int16x8} value An instance of int16x8.
+  * @return {void}
+  */
+SIMD.int16x8.store = function(tarray, index, value) {
+  if (!isTypedArray(tarray))
+    throw new TypeError("The 1st argument must be a typed array.");
+  if (!isNumber(index))
+    throw new TypeError("The 2nd argument must be a Number.");
+  var bpe = tarray.BYTES_PER_ELEMENT;
+  if (index < 0 || (index * bpe + 16) > tarray.byteLength)
+    throw new RangeError("The value of index is invalid.");
+  value = SIMD.int16x8(value);
+  _PRIVATE._i16x8[0] = value.s0;
+  _PRIVATE._i16x8[1] = value.s1;
+  _PRIVATE._i16x8[2] = value.s2;
+  _PRIVATE._i16x8[3] = value.s3;
+  _PRIVATE._i16x8[4] = value.s4;
+  _PRIVATE._i16x8[5] = value.s5;
+  _PRIVATE._i16x8[6] = value.s6;
+  _PRIVATE._i16x8[7] = value.s7;
+  var array = bpe == 1 ? _PRIVATE._i8x16 :
+              bpe == 2 ? _PRIVATE._i16x8 :
+              bpe == 4 ? (tarray instanceof Float32Array ? _PRIVATE._f32x4 : _PRIVATE._i32x4) :
+              _PRIVATE._f64x2;
+  var n = 16 / bpe;
+  for (var i = 0; i < n; ++i)
+    tarray[index + i] = array[i];
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a & b.
+  */
+SIMD.int8x16.and = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(a.s0 & b.s0, a.s1 & b.s1, a.s2 & b.s2, a.s3 & b.s3,
+                      a.s4 & b.s4, a.s5 & b.s5, a.s6 & b.s6, a.s7 & b.s7,
+                      a.s8 & b.s8, a.s9 & b.s9, a.s10 & b.s10, a.s11 & b.s11,
+                      a.s12 & b.s12, a.s13 & b.s13, a.s14 & b.s14, a.s15 & b.s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a | b.
+  */
+SIMD.int8x16.or = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(a.s0 | b.s0, a.s1 | b.s1, a.s2 | b.s2, a.s3 | b.s3,
+                      a.s4 | b.s4, a.s5 | b.s5, a.s6 | b.s6, a.s7 | b.s7,
+                      a.s8 | b.s8, a.s9 | b.s9, a.s10 | b.s10, a.s11 | b.s11,
+                      a.s12 | b.s12, a.s13 | b.s13, a.s14 | b.s14, a.s15 | b.s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a ^ b.
+  */
+SIMD.int8x16.xor = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(a.s0 ^ b.s0, a.s1 ^ b.s1, a.s2 ^ b.s2, a.s3 ^ b.s3,
+                      a.s4 ^ b.s4, a.s5 ^ b.s5, a.s6 ^ b.s6, a.s7 ^ b.s7,
+                      a.s8 ^ b.s8, a.s9 ^ b.s9, a.s10 ^ b.s10, a.s11 ^ b.s11,
+                      a.s12 ^ b.s12, a.s13 ^ b.s13, a.s14 ^ b.s14, a.s15 ^ b.s15);
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of ~t
+  */
+SIMD.int8x16.not = function(t) {
+  checkInt8x16(t);
+  return SIMD.int8x16(~t.s0, ~t.s1, ~t.s2, ~t.s3,
+                      ~t.s4, ~t.s5, ~t.s6, ~t.s7,
+                      ~t.s8, ~t.s9, ~t.s10, ~t.s11,
+                      ~t.s12, ~t.s13, ~t.s14, ~t.s15);
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of -t
+  */
+SIMD.int8x16.neg = function(t) {
+  checkInt8x16(t);
+  return SIMD.int8x16(-t.s0, -t.s1, -t.s2, -t.s3,
+                      -t.s4, -t.s5, -t.s6, -t.s7,
+                      -t.s8, -t.s9, -t.s10, -t.s11,
+                      -t.s12, -t.s13, -t.s14, -t.s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a + b.
+  */
+SIMD.int8x16.add = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(a.s0 + b.s0, a.s1 + b.s1, a.s2 + b.s2, a.s3 + b.s3,
+                      a.s4 + b.s4, a.s5 + b.s5, a.s6 + b.s6, a.s7 + b.s7,
+                      a.s8 + b.s8, a.s9 + b.s9, a.s10 + b.s10, a.s11 + b.s11,
+                      a.s12 + b.s12, a.s13 + b.s13, a.s14 + b.s14, a.s15 + b.s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a - b.
+  */
+SIMD.int8x16.sub = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(a.s0 - b.s0, a.s1 - b.s1, a.s2 - b.s2, a.s3 - b.s3,
+                      a.s4 - b.s4, a.s5 - b.s5, a.s6 - b.s6, a.s7 - b.s7,
+                      a.s8 - b.s8, a.s9 - b.s9, a.s10 - b.s10, a.s11 - b.s11,
+                      a.s12 - b.s12, a.s13 - b.s13, a.s14 - b.s14, a.s15 - b.s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int8x16} b An instance of int8x16.
+  * @return {int8x16} New instance of int8x16 with values of a * b.
+  */
+SIMD.int8x16.mul = function(a, b) {
+  checkInt8x16(a);
+  checkInt8x16(b);
+  return SIMD.int8x16(Math.imul(a.s0, b.s0), Math.imul(a.s1, b.s1),
+                      Math.imul(a.s2, b.s2), Math.imul(a.s3, b.s3),
+                      Math.imul(a.s4, b.s4), Math.imul(a.s5, b.s5),
+                      Math.imul(a.s6, b.s6), Math.imul(a.s7, b.s7),
+                      Math.imul(a.s8, b.s8), Math.imul(a.s9, b.s9),
+                      Math.imul(a.s10, b.s10), Math.imul(a.s11, b.s11),
+                      Math.imul(a.s12, b.s12), Math.imul(a.s13, b.s13),
+                      Math.imul(a.s14, b.s14), Math.imul(a.s15, b.s15));
+}
+
+/**
+  * @param {int8x16} t Selector mask. An instance of int8x16
+  * @param {int8x16} trueValue Pick lane from here if corresponding
+  * selector lane is 0xFF
+  * @param {int8x16} falseValue Pick lane from here if corresponding
+  * selector lane is 0x0
+  * @return {int8x16} Mix of lanes from trueValue or falseValue as
+  * indicated
+  */
+SIMD.int8x16.select = function(t, trueValue, falseValue) {
+  checkInt8x16(t);
+  checkInt8x16(trueValue);
+  checkInt8x16(falseValue);
+  var tr = SIMD.int8x16.and(t, trueValue);
+  var fr = SIMD.int8x16.and(SIMD.int8x16.not(t), falseValue);
+  return SIMD.int8x16.or(tr, fr);
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @param {int8x16} other An instance of int8x16.
+  * @return {int8x16} 0xFF or 0x0 in each lane depending on
+  * the result of t == other.
+  */
+SIMD.int8x16.equal = function(t, other) {
+  checkInt8x16(t);
+  checkInt8x16(other);
+  var cs0 = t.s0 == other.s0;
+  var cs1 = t.s1 == other.s1;
+  var cs2 = t.s2 == other.s2;
+  var cs3 = t.s3 == other.s3;
+  var cs4 = t.s4 == other.s4;
+  var cs5 = t.s5 == other.s5;
+  var cs6 = t.s6 == other.s6;
+  var cs7 = t.s7 == other.s7;
+  var cs8 = t.s8 == other.s8;
+  var cs9 = t.s9 == other.s9;
+  var cs10 = t.s10 == other.s10;
+  var cs11 = t.s11 == other.s11;
+  var cs12 = t.s12 == other.s12;
+  var cs13 = t.s13 == other.s13;
+  var cs14 = t.s14 == other.s14;
+  var cs15 = t.s15 == other.s15;
+  return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                           cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @param {int8x16} other An instance of int8x16.
+  * @return {int8x16} 0xFF or 0x0 in each lane depending on
+  * the result of t > other.
+  */
+SIMD.int8x16.greaterThan = function(t, other) {
+  checkInt8x16(t);
+  checkInt8x16(other);
+  var cs0 = t.s0 > other.s0;
+  var cs1 = t.s1 > other.s1;
+  var cs2 = t.s2 > other.s2;
+  var cs3 = t.s3 > other.s3;
+  var cs4 = t.s4 > other.s4;
+  var cs5 = t.s5 > other.s5;
+  var cs6 = t.s6 > other.s6;
+  var cs7 = t.s7 > other.s7;
+  var cs8 = t.s8 > other.s8;
+  var cs9 = t.s9 > other.s9;
+  var cs10 = t.s10 > other.s10;
+  var cs11 = t.s11 > other.s11;
+  var cs12 = t.s12 > other.s12;
+  var cs13 = t.s13 > other.s13;
+  var cs14 = t.s14 > other.s14;
+  var cs15 = t.s15 > other.s15;
+  return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                           cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+}
+
+/**
+  * @param {int8x16} t An instance of int8x16.
+  * @param {int8x16} other An instance of int8x16.
+  * @return {int8x16} 0xFF or 0x0 in each lane depending on
+  * the result of t < other.
+  */
+SIMD.int8x16.lessThan = function(t, other) {
+  checkInt8x16(t);
+  checkInt8x16(other);
+  var cs0 = t.s0 < other.s0;
+  var cs1 = t.s1 < other.s1;
+  var cs2 = t.s2 < other.s2;
+  var cs3 = t.s3 < other.s3;
+  var cs4 = t.s4 < other.s4;
+  var cs5 = t.s5 < other.s5;
+  var cs6 = t.s6 < other.s6;
+  var cs7 = t.s7 < other.s7;
+  var cs8 = t.s8 < other.s8;
+  var cs9 = t.s9 < other.s9;
+  var cs10 = t.s10 < other.s10;
+  var cs11 = t.s11 < other.s11;
+  var cs12 = t.s12 < other.s12;
+  var cs13 = t.s13 < other.s13;
+  var cs14 = t.s14 < other.s14;
+  var cs15 = t.s15 < other.s15;
+  return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                           cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int} bits Bit count to shift by.
+  * @return {int8x16} lanes in a shifted by bits.
+  */
+SIMD.int8x16.shiftLeftByScalar = function(a, bits) {
+  checkInt8x16(a);
+  var s0 = a.s0 << bits;
+  var s1 = a.s1 << bits;
+  var s2 = a.s2 << bits;
+  var s3 = a.s3 << bits;
+  var s4 = a.s4 << bits;
+  var s5 = a.s5 << bits;
+  var s6 = a.s6 << bits;
+  var s7 = a.s7 << bits;
+  var s8 = a.s8 << bits;
+  var s9 = a.s9 << bits;
+  var s10 = a.s10 << bits;
+  var s11 = a.s11 << bits;
+  var s12 = a.s12 << bits;
+  var s13 = a.s13 << bits;
+  var s14 = a.s14 << bits;
+  var s15 = a.s15 << bits;
+  return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                      s8, s9, s10, s11, s12, s13, s14, s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int} bits Bit count to shift by.
+  * @return {int8x16} lanes in a shifted by bits.
+  */
+SIMD.int8x16.shiftRightLogicalByScalar = function(a, bits) {
+  checkInt8x16(a);
+  var s0 = (a.s0 & 0xff) >>> bits;
+  var s1 = (a.s1 & 0xff) >>> bits;
+  var s2 = (a.s2 & 0xff) >>> bits;
+  var s3 = (a.s3 & 0xff) >>> bits;
+  var s4 = (a.s4 & 0xff) >>> bits;
+  var s5 = (a.s5 & 0xff) >>> bits;
+  var s6 = (a.s6 & 0xff) >>> bits;
+  var s7 = (a.s7 & 0xff) >>> bits;
+  var s8 = (a.s8 & 0xff) >>> bits;
+  var s9 = (a.s9 & 0xff) >>> bits;
+  var s10 = (a.s10 & 0xff) >>> bits;
+  var s11 = (a.s11 & 0xff) >>> bits;
+  var s12 = (a.s12 & 0xff) >>> bits;
+  var s13 = (a.s13 & 0xff) >>> bits;
+  var s14 = (a.s14 & 0xff) >>> bits;
+  var s15 = (a.s15 & 0xff) >>> bits;
+  return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                      s8, s9, s10, s11, s12, s13, s14, s15);
+}
+
+/**
+  * @param {int8x16} a An instance of int8x16.
+  * @param {int} bits Bit count to shift by.
+  * @return {int8x16} lanes in a shifted by bits.
+  */
+SIMD.int8x16.shiftRightArithmeticByScalar = function(a, bits) {
+  checkInt8x16(a);
+  var s0 = a.s0 >> bits;
+  var s1 = a.s1 >> bits;
+  var s2 = a.s2 >> bits;
+  var s3 = a.s3 >> bits;
+  var s4 = a.s4 >> bits;
+  var s5 = a.s5 >> bits;
+  var s6 = a.s6 >> bits;
+  var s7 = a.s7 >> bits;
+  var s8 = a.s8 >> bits;
+  var s9 = a.s9 >> bits;
+  var s10 = a.s10 >> bits;
+  var s11 = a.s11 >> bits;
+  var s12 = a.s12 >> bits;
+  var s13 = a.s13 >> bits;
+  var s14 = a.s14 >> bits;
+  var s15 = a.s15 >> bits;
+  return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                      s8, s9, s10, s11, s12, s13, s14, s15);
+}
+
+/**
+  * @param {Typed array} buffer An instance of a typed array.
+  * @param {Number} index An instance of Number.
+  * @return {int8x16} New instance of int8x16.
+  */
+SIMD.int8x16.load = function(tarray, index) {
+  if (!isTypedArray(tarray))
+    throw new TypeError("The 1st argument must be a typed array.");
+  if (!_PRIVATE.isNumber(index))
+    throw new TypeError("The 2nd argument must be a Number.");
+  var bpe = tarray.BYTES_PER_ELEMENT;
+  if (index < 0 || (index * bpe + 16) > tarray.byteLength)
+    throw new RangeError("The value of index is invalid.");
+  var i8temp = _PRIVATE._i16x8;
+  var array = bpe == 1 ? i8temp :
+              bpe == 2 ? _PRIVATE._i16x8 :
+              bpe == 4 ? (tarray instanceof Float32Array ? _PRIVATE._f32x4 : _PRIVATE._i32x4) :
+              _PRIVATE._f64x2;
+  var n = 16 / bpe;
+  for (var i = 0; i < n; ++i)
+    array[i] = tarray[index + i];
+  return new SIMD.int8x16(i8temp[0], i8temp[1], i8temp[2], i8temp[3],
+                          i8temp[4], i8temp[5], i8temp[6], i8temp[7],
+                          i8temp[8], i8temp[9], i8temp[10], i8temp[11],
+                          i8temp[12], i8temp[13], i8temp[14], i8temp[15]);
+}
+
+/**
+  * @param {Typed array} tarray An instance of a typed array.
+  * @param {Number} index An instance of Number.
+  * @param {int8x16} value An instance of int8x16.
+  * @return {void}
+  */
+SIMD.int8x16.store = function(tarray, index, value) {
+  if (!isTypedArray(tarray))
+    throw new TypeError("The 1st argument must be a typed array.");
+  if (!isNumber(index))
+    throw new TypeError("The 2nd argument must be a Number.");
+  var bpe = tarray.BYTES_PER_ELEMENT;
+  if (index < 0 || (index * bpe + 16) > tarray.byteLength)
+    throw new RangeError("The value of index is invalid.");
+  value = SIMD.int8x16(value);
+  _PRIVATE._i8x16[0] = value.s0;
+  _PRIVATE._i8x16[1] = value.s1;
+  _PRIVATE._i8x16[2] = value.s2;
+  _PRIVATE._i8x16[3] = value.s3;
+  _PRIVATE._i8x16[4] = value.s4;
+  _PRIVATE._i8x16[5] = value.s5;
+  _PRIVATE._i8x16[6] = value.s6;
+  _PRIVATE._i8x16[7] = value.s7;
+  _PRIVATE._i8x16[8] = value.s8;
+  _PRIVATE._i8x16[9] = value.s9;
+  _PRIVATE._i8x16[10] = value.s10;
+  _PRIVATE._i8x16[11] = value.s11;
+  _PRIVATE._i8x16[12] = value.s12;
+  _PRIVATE._i8x16[13] = value.s13;
+  _PRIVATE._i8x16[14] = value.s14;
+  _PRIVATE._i8x16[15] = value.s15;
+  var array = bpe == 1 ? _PRIVATE._i8x16 :
+              bpe == 2 ? _PRIVATE._i16x8 :
+              bpe == 4 ? (tarray instanceof Float32Array ? _PRIVATE._f32x4 : _PRIVATE._i32x4) :
+              _PRIVATE._f64x2;
+  var n = 16 / bpe;
+  for (var i = 0; i < n; ++i)
+    tarray[index + i] = array[i];
+}
+
 Object.defineProperty(SIMD.float32x4.prototype, 'x', {
   get: function() { return this.x_; }
 });
@@ -1989,6 +3004,148 @@ Object.defineProperty(SIMD.int32x4.prototype, 'signMask', {
     var mz = _PRIVATE.tobool(this.z_);
     var mw = _PRIVATE.tobool(this.w_);
     return mx | my << 1 | mz << 2 | mw << 3;
+  }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's0', {
+  get: function() { return this.s0_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's1', {
+  get: function() { return this.s1_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's2', {
+  get: function() { return this.s2_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's3', {
+  get: function() { return this.s3_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's4', {
+  get: function() { return this.s4_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's5', {
+  get: function() { return this.s5_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's6', {
+  get: function() { return this.s6_; }
+});
+
+Object.defineProperty(SIMD.int16x8.prototype, 's7', {
+  get: function() { return this.s7_; }
+});
+
+/**
+  * Extract the sign bit from each lane return them in the first 8 bits.
+  */
+Object.defineProperty(SIMD.int16x8.prototype, 'signMask', {
+  get: function() {
+    var ms0 = (this.s0_ & 0x8000) >>> 15;
+    var ms1 = (this.s1_ & 0x8000) >>> 15;
+    var ms2 = (this.s2_ & 0x8000) >>> 15;
+    var ms3 = (this.s3_ & 0x8000) >>> 15;
+    var ms4 = (this.s4_ & 0x8000) >>> 15;
+    var ms5 = (this.s5_ & 0x8000) >>> 15;
+    var ms6 = (this.s6_ & 0x8000) >>> 15;
+    var ms7 = (this.s7_ & 0x8000) >>> 15;
+    return ms0 | ms1 << 1 | ms2 << 2 | ms3 << 3 |
+           ms4 << 4 | ms5 << 5 | ms6 << 6 | ms7 << 7;
+  }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's0', {
+  get: function() { return this.s0_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's1', {
+  get: function() { return this.s1_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's2', {
+  get: function() { return this.s2_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's3', {
+  get: function() { return this.s3_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's4', {
+  get: function() { return this.s4_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's5', {
+  get: function() { return this.s5_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's6', {
+  get: function() { return this.s6_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's7', {
+  get: function() { return this.s7_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's8', {
+  get: function() { return this.s8_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's9', {
+  get: function() { return this.s9_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's10', {
+  get: function() { return this.s10_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's11', {
+  get: function() { return this.s11_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's12', {
+  get: function() { return this.s12_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's13', {
+  get: function() { return this.s13_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's14', {
+  get: function() { return this.s14_; }
+});
+
+Object.defineProperty(SIMD.int8x16.prototype, 's15', {
+  get: function() { return this.s15_; }
+});
+
+/**
+  * Extract the sign bit from each lane return them in the first 16 bits.
+  */
+Object.defineProperty(SIMD.int8x16.prototype, 'signMask', {
+  get: function() {
+    var ms0 = (this.s0_ & 0x80) >>> 7;
+    var ms1 = (this.s1_ & 0x80) >>> 7;
+    var ms2 = (this.s2_ & 0x80) >>> 7;
+    var ms3 = (this.s3_ & 0x80) >>> 7;
+    var ms4 = (this.s4_ & 0x80) >>> 7;
+    var ms5 = (this.s5_ & 0x80) >>> 7;
+    var ms6 = (this.s6_ & 0x80) >>> 7;
+    var ms7 = (this.s7_ & 0x80) >>> 7;
+    var ms8 = (this.s8_ & 0x80) >>> 7;
+    var ms9 = (this.s9_ & 0x80) >>> 7;
+    var ms10 = (this.s10_ & 0x80) >>> 7;
+    var ms11 = (this.s11_ & 0x80) >>> 7;
+    var ms12 = (this.s12_ & 0x80) >>> 7;
+    var ms13 = (this.s13_ & 0x80) >>> 7;
+    var ms14 = (this.s14_ & 0x80) >>> 7;
+    var ms15 = (this.s15_ & 0x80) >>> 7;
+    return ms0 | ms1 << 1 | ms2 << 2 | ms3 << 3 |
+           ms4 << 4 | ms5 << 5 | ms6 << 6 | ms7 << 7 |
+           ms8 << 8 | ms9 << 9 | ms10 << 10 | ms11 << 11 |
+           ms12 << 12 | ms13 << 13 | ms14 << 14 | ms15 << 15;
   }
 });
 
@@ -2259,6 +3416,48 @@ DataView.prototype.getInt32x4 = function(byteOffset, littleEndian) {
                       this.getInt32(byteOffset + 12, littleEndian));
 }
 
+DataView.prototype.getInt16x8 = function(byteOffset, littleEndian) {
+  if (!isDataView(this))
+    throw new TypeError("This is not a DataView.");
+  if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  if (typeof littleEndian == 'undefined')
+    littleEndian = false;
+  return SIMD.int16x8(this.getInt16(byteOffset, littleEndian),
+                      this.getInt16(byteOffset + 2, littleEndian),
+                      this.getInt16(byteOffset + 4, littleEndian),
+                      this.getInt16(byteOffset + 6, littleEndian),
+                      this.getInt16(byteOffset + 8, littleEndian),
+                      this.getInt16(byteOffset + 10, littleEndian),
+                      this.getInt16(byteOffset + 12, littleEndian),
+                      this.getInt16(byteOffset + 14, littleEndian));
+}
+
+DataView.prototype.getInt8x16 = function(byteOffset, littleEndian) {
+  if (!isDataView(this))
+    throw new TypeError("This is not a DataView.");
+  if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  if (typeof littleEndian == 'undefined')
+    littleEndian = false;
+  return SIMD.int8x16(this.getInt8(byteOffset, littleEndian),
+                      this.getInt8(byteOffset + 1, littleEndian),
+                      this.getInt8(byteOffset + 2, littleEndian),
+                      this.getInt8(byteOffset + 3, littleEndian),
+                      this.getInt8(byteOffset + 4, littleEndian),
+                      this.getInt8(byteOffset + 5, littleEndian),
+                      this.getInt8(byteOffset + 6, littleEndian),
+                      this.getInt8(byteOffset + 7, littleEndian),
+                      this.getInt8(byteOffset + 8, littleEndian),
+                      this.getInt8(byteOffset + 9, littleEndian),
+                      this.getInt8(byteOffset + 10, littleEndian),
+                      this.getInt8(byteOffset + 11, littleEndian),
+                      this.getInt8(byteOffset + 12, littleEndian),
+                      this.getInt8(byteOffset + 13, littleEndian),
+                      this.getInt8(byteOffset + 14, littleEndian),
+                      this.getInt8(byteOffset + 15, littleEndian));
+}
+
 DataView.prototype.setFloat32x4 = function(byteOffset, value, littleEndian) {
   if (!isDataView(this))
     throw new TypeError("This is not a DataView.");
@@ -2297,4 +3496,48 @@ DataView.prototype.setInt32x4 = function(byteOffset, value, littleEndian) {
   this.setInt32(byteOffset + 4, value.y, littleEndian);
   this.setInt32(byteOffset + 8, value.z, littleEndian);
   this.setInt32(byteOffset + 12, value.w, littleEndian);
+}
+
+DataView.prototype.setInt16x8 = function(byteOffset, value, littleEndian) {
+  if (!isDataView(this))
+    throw new TypeError("This is not a DataView.");
+  if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt16x8(value);
+  if (typeof littleEndian == 'undefined')
+    littleEndian = false;
+  this.setInt16(byteOffset, value.s0, littleEndian);
+  this.setInt16(byteOffset + 2, value.s1, littleEndian);
+  this.setInt16(byteOffset + 4, value.s2, littleEndian);
+  this.setInt16(byteOffset + 6, value.s3, littleEndian);
+  this.setInt16(byteOffset + 8, value.s4, littleEndian);
+  this.setInt16(byteOffset + 10, value.s5, littleEndian);
+  this.setInt16(byteOffset + 12, value.s6, littleEndian);
+  this.setInt16(byteOffset + 14, value.s7, littleEndian);
+}
+
+DataView.prototype.setInt8x16 = function(byteOffset, value, littleEndian) {
+  if (!isDataView(this))
+    throw new TypeError("This is not a DataView.");
+  if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
+    throw new RangeError("The value of byteOffset is invalid.");
+  checkInt8x16(value);
+  if (typeof littleEndian == 'undefined')
+    littleEndian = false;
+  this.setInt8(byteOffset, value.s0, littleEndian);
+  this.setInt8(byteOffset + 1, value.s1, littleEndian);
+  this.setInt8(byteOffset + 2, value.s2, littleEndian);
+  this.setInt8(byteOffset + 3, value.s3, littleEndian);
+  this.setInt8(byteOffset + 4, value.s4, littleEndian);
+  this.setInt8(byteOffset + 5, value.s5, littleEndian);
+  this.setInt8(byteOffset + 6, value.s6, littleEndian);
+  this.setInt8(byteOffset + 7, value.s7, littleEndian);
+  this.setInt8(byteOffset + 8, value.s8, littleEndian);
+  this.setInt8(byteOffset + 9, value.s9, littleEndian);
+  this.setInt8(byteOffset + 10, value.s10, littleEndian);
+  this.setInt8(byteOffset + 11, value.s11, littleEndian);
+  this.setInt8(byteOffset + 12, value.s12, littleEndian);
+  this.setInt8(byteOffset + 13, value.s13, littleEndian);
+  this.setInt8(byteOffset + 14, value.s14, littleEndian);
+  this.setInt8(byteOffset + 15, value.s15, littleEndian);
 }

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -46,6 +46,16 @@ test('coercive constructors', function() {
   equal(SIMD.float64x2(z), z);
   throws(function() {SIMD.float64x2(1)});
   throws(function() {SIMD.float64x2('hi')});
+
+  var u = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  equal(SIMD.int16x8(u), u);
+  throws(function() {SIMD.int16x8(1)});
+  throws(function() {SIMD.int16x8('hi')});
+
+  var v = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  equal(SIMD.int8x16(v), v);
+  throws(function() {SIMD.int8x16(1)});
+  throws(function() {SIMD.int8x16('hi')});
 });
 
 test('float32x4 fromFloat64x2 constructor', function() {
@@ -92,6 +102,24 @@ test('float32x4 fromFloat64x2Bits constructor', function() {
 test('float32x4 fromInt32x4Bits constructor', function() {
   var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var n = SIMD.float32x4.fromInt32x4Bits(m);
+  equal(1.0, n.x);
+  equal(2.0, n.y);
+  equal(3.0, n.z);
+  equal(4.0, n.w);
+});
+
+test('float32x4 fromInt16x8Bits constructor', function() {
+  var m = SIMD.int16x8(0x0000, 0x3F80, 0x0000, 0x4000, 0x0000, 0x4040, 0x0000, 0x4080);
+  var n = SIMD.float32x4.fromInt16x8Bits(m);
+  equal(1.0, n.x);
+  equal(2.0, n.y);
+  equal(3.0, n.z);
+  equal(4.0, n.w);
+});
+
+test('float32x4 fromInt8x16Bits constructor', function() {
+  var m = SIMD.int8x16(0x0, 0x0, 0x80, 0x3F, 0x0, 0x0, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40, 0x00, 0x00, 0x80, 0x40);
+  var n = SIMD.float32x4.fromInt8x16Bits(m);
   equal(1.0, n.x);
   equal(2.0, n.y);
   equal(3.0, n.z);
@@ -1195,8 +1223,22 @@ test('float64x2 fromFloat32x4Bits constructor', function() {
 });
 
 test('float64x2 fromInt32x4Bits constructor', function() {
-  var m = SIMD.int32x4(0x00000000, 0x3ff00000, 0x0000000, 0x40000000);
+  var m = SIMD.int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000);
   var n = SIMD.float64x2.fromInt32x4Bits(m);
+  equal(1.0, n.x);
+  equal(2.0, n.y);
+});
+
+test('float64x2 fromInt16x8Bits constructor', function() {
+  var m = SIMD.int16x8(0x0000, 0x0000, 0x0000, 0x3ff0, 0x0000, 0x0000, 0x0000, 0x4000);
+  var n = SIMD.float64x2.fromInt16x8Bits(m);
+  equal(1.0, n.x);
+  equal(2.0, n.y);
+});
+
+test('float64x2 fromInt8x16Bits constructor', function() {
+  var m = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40);
+  var n = SIMD.float64x2.fromInt8x16Bits(m);
   equal(1.0, n.x);
   equal(2.0, n.y);
 });
@@ -2820,6 +2862,894 @@ test('int32x4 storeXYZ exceptions', function () {
   });
 });
 
+test('int16x8 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.int16x8.fromFloat32x4Bits(m);
+  equal(0x0000, n.s0);
+  equal(0x3F80, n.s1);
+  equal(0x0000, n.s2);
+  equal(0x4000, n.s3);
+  equal(0x0000, n.s4);
+  equal(0x4040, n.s5);
+  equal(0x0000, n.s6);
+  equal(0x4080, n.s7);
+});
+
+test('int16x8 and', function() {
+  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 43690, 43690, 0xAAAA, 0xAAAA);
+  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  equal(-21846, m.s0);
+  equal(-21846, m.s1);
+  equal(-21846, m.s2);
+  equal(-21846, m.s3);
+  equal(-21846, m.s4);
+  equal(-21846, m.s5);
+  equal(-21846, m.s6);
+  equal(-21846, m.s7);
+  equal(0x5555, n.s0);
+  equal(0x5555, n.s1);
+  equal(0x5555, n.s2);
+  equal(0x5555, n.s3);
+  equal(0x5555, n.s4);
+  equal(0x5555, n.s5);
+  equal(0x5555, n.s6);
+  equal(0x5555, n.s7);
+  var o = SIMD.int16x8.and(m,n);  // and
+  equal(0x0, o.s0);
+  equal(0x0, o.s1);
+  equal(0x0, o.s2);
+  equal(0x0, o.s3);
+  equal(0x0, o.s4);
+  equal(0x0, o.s5);
+  equal(0x0, o.s6);
+  equal(0x0, o.s7);
+});
+
+test('int16x8 or', function() {
+  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
+  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  var o = SIMD.int16x8.or(m,n);  // or
+  equal(-1, o.s0);
+  equal(-1, o.s1);
+  equal(-1, o.s2);
+  equal(-1, o.s3);
+  equal(-1, o.s4);
+  equal(-1, o.s5);
+  equal(-1, o.s6);
+  equal(-1, o.s7);
+});
+
+test('int16x8 xor', function() {
+  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
+  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  var o = SIMD.int16x8.xor(m,n);  // xor
+  equal(-1, o.s0);
+  equal(-1, o.s1);
+  equal(-1, o.s2);
+  equal(-1, o.s3);
+  equal(-1, o.s4);
+  equal(-1, o.s5);
+  equal(-1, o.s6);
+  equal(-1, o.s7);
+  o = SIMD.int16x8.xor(m,m);  // xor
+  equal(0x0, o.s0);
+  equal(0x0, o.s1);
+  equal(0x0, o.s2);
+  equal(0x0, o.s3);
+  equal(0x0, o.s4);
+  equal(0x0, o.s5);
+  equal(0x0, o.s6);
+  equal(0x0, o.s7);
+});
+
+test('int16x8 neg', function() {
+  var m = SIMD.int16x8(16, -32, 64, -128, 256, -512, 1024, -2048);
+  m = SIMD.int16x8.neg(m);
+  equal(-16, m.s0);
+  equal(32, m.s1);
+  equal(-64, m.s2);
+  equal(128, m.s3);
+  equal(-256, m.s4);
+  equal(512, m.s5);
+  equal(-1024, m.s6);
+  equal(2048, m.s7);
+
+  var n = SIMD.int16x8(0, 0, 0x7fff, 0xffff, -1, -1, 0x8000, 0x0000);
+  n = SIMD.int16x8.neg(n);
+  equal(0, n.s0);
+  equal(0, n.s1);
+  equal(-32767, n.s2);
+  equal(1, n.s3);
+  equal(1, n.s4);
+  equal(1, n.s5);
+  equal(-32768, n.s6);
+  equal(0, n.s7);
+});
+
+test('int16x8 signMask getter', function() {
+  var a = SIMD.int16x8(0x8000, 0x0000, 0x700, 0x0000, 0xFFFF, 0xFFFF, 0x0, 0x0);
+  equal(0x31, a.signMask);
+  var b = SIMD.int16x8(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+  equal(0x0, b.signMask);
+  var c = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+  equal(0xff, c.signMask);
+});
+
+
+test('int16x8 add', function() {
+  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x7fff, 0xffff, 0x0, 0x0);
+  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
+  var c = SIMD.int16x8.add(a, b);
+  equal(-1, c.s0);
+  equal(0, c.s1);
+  equal(-2, c.s2);
+  equal(-2, c.s3);
+  equal(0x7fff, c.s4);
+  equal(0, c.s5);
+  equal(-1, c.s6);
+  equal(-1, c.s7);
+});
+
+test('int16x8 sub', function() {
+  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
+  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0x0FFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
+  var c = SIMD.int16x8.sub(a, b);
+  equal(-1, c.s0);
+  equal(-2, c.s1);
+  equal(0, c.s2);
+  equal(0, c.s3);
+  equal(-32768, c.s4);
+  equal(-1, c.s5);
+  equal(1, c.s6);
+  equal(1, c.s7);
+});
+
+test('int16x8 mul', function() {
+  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
+  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0xFFFF, 0xFFFF);
+  var c = SIMD.int16x8.mul(a, b);
+  equal(0, c.s0);
+  equal(-1, c.s1);
+  equal(1, c.s2);
+  equal(1, c.s3);
+  equal(0, c.s4);
+  equal(0, c.s5);
+  equal(0, c.s6);
+  equal(0, c.s7);
+});
+
+test('int16x8 comparisons', function() {
+  var m = SIMD.int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
+  var n = SIMD.int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
+  var cmp;
+  cmp = SIMD.int16x8.lessThan(m, n);
+  equal(0x0, cmp.s0);
+  equal(0x0, cmp.s1);
+  equal(0x0, cmp.s2);
+  equal(-1, cmp.s3);
+  equal(-1, cmp.s4);
+  equal(0x0, cmp.s5);
+  equal(-1, cmp.s6);
+  equal(0x0, cmp.s7);
+
+  cmp = SIMD.int16x8.equal(m, n);
+  equal(0x0, cmp.s0);
+  equal(-1, cmp.s1);
+  equal(0x0, cmp.s2);
+  equal(0x0, cmp.s3);
+  equal(0x0, cmp.s4);
+  equal(-1, cmp.s5);
+  equal(0x0, cmp.s6);
+  equal(0x0, cmp.s7);
+
+  cmp = SIMD.int16x8.greaterThan(m, n);
+  equal(-1, cmp.s0);
+  equal(0, cmp.s1);
+  equal(-1, cmp.s2);
+  equal(0, cmp.s3);
+  equal(0, cmp.s4);
+  equal(0, cmp.s5);
+  equal(0, cmp.s6);
+  equal(-1, cmp.s7);
+});
+
+test('int16x8 shiftLeftByScalar', function() {
+  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int16x8.shiftLeftByScalar(a, 1);
+  equal(b.s0, -2);
+  equal(b.s1, -2);
+  equal(b.s2, -2);
+  equal(b.s3, -2);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0002);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftLeftByScalar(a, 2);
+  equal(b.s0, -4);
+  equal(b.s1, -4);
+  equal(b.s2, -4);
+  equal(b.s3, -4);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0004);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftLeftByScalar(a, 14);
+  equal(b.s0, -16384);
+  equal(b.s1, -16384);
+  equal(b.s2, -16384);
+  equal(b.s3, -16384);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x4000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftLeftByScalar(a, 15);
+  equal(b.s0, -32768);
+  equal(b.s1, -32768);
+  equal(b.s2, -32768);
+  equal(b.s3, -32768);
+  equal(b.s4, 0x0000);
+  equal(b.s5, -32768);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+});
+
+test('int16x8 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 1);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, 0x3fff);
+  equal(b.s3, -1);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 2);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, 0x1fff);
+  equal(b.s3, -1);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 14);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, 0x0001);
+  equal(b.s3, -1);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 15);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, 0x0000);
+  equal(b.s3, -1);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+});
+
+test('int16x8 shiftRightLogicalByScalar', function() {
+  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 1);
+  equal(b.s0, 0x7fff);
+  equal(b.s1, 0x7fff);
+  equal(b.s2, 0x3fff);
+  equal(b.s3, 0x7fff);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 2);
+  equal(b.s0, 0x3fff);
+  equal(b.s1, 0x3fff);
+  equal(b.s2, 0x1fff);
+  equal(b.s3, 0x3fff);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 14);
+  equal(b.s0, 0x0003);
+  equal(b.s1, 0x0003);
+  equal(b.s2, 0x0001);
+  equal(b.s3, 0x0003);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 15);
+  equal(b.s0, 0x0001);
+  equal(b.s1, 0x0001);
+  equal(b.s2, 0x0000);
+  equal(b.s3, 0x0001);
+  equal(b.s4, 0x0000);
+  equal(b.s5, 0x0000);
+  equal(b.s6, 0x0000);
+  equal(b.s7, 0x0000);
+});
+
+test('int16x8 select', function() {
+  var m = SIMD.int16x8.bool(true, true, true, true, false, false, false, false);
+  var t = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var f = SIMD.int16x8(9, 10, 11, 12, 13, 14, 15, 16);
+  var s = SIMD.int16x8.select(m, t, f);
+  equal(1, s.s0);
+  equal(2, s.s1);
+  equal(3, s.s2);
+  equal(4, s.s3);
+  equal(13, s.s4);
+  equal(14, s.s5);
+  equal(15, s.s6);
+  equal(16, s.s7);
+});
+
+test('int8x16 and', function() {
+  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 170, 170, 170, 170, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  equal(-86, m.s0);
+  equal(-86, m.s1);
+  equal(-86, m.s2);
+  equal(-86, m.s3);
+  equal(-86, m.s4);
+  equal(-86, m.s5);
+  equal(-86, m.s6);
+  equal(-86, m.s7);
+  equal(-86, m.s8);
+  equal(-86, m.s9);
+  equal(-86, m.s10);
+  equal(-86, m.s11);
+  equal(-86, m.s12);
+  equal(-86, m.s13);
+  equal(-86, m.s14);
+  equal(-86, m.s15);
+  equal(85, n.s0);
+  equal(85, n.s1);
+  equal(85, n.s2);
+  equal(85, n.s3);
+  equal(85, n.s4);
+  equal(85, n.s5);
+  equal(85, n.s6);
+  equal(85, n.s7);
+  equal(85, n.s8);
+  equal(85, n.s9);
+  equal(85, n.s10);
+  equal(85, n.s11);
+  equal(85, n.s12);
+  equal(85, n.s13);
+  equal(85, n.s14);
+  equal(85, n.s15);
+  var o = SIMD.int8x16.and(m,n);  // and
+  equal(0x0, o.s0);
+  equal(0x0, o.s1);
+  equal(0x0, o.s2);
+  equal(0x0, o.s3);
+  equal(0x0, o.s4);
+  equal(0x0, o.s5);
+  equal(0x0, o.s6);
+  equal(0x0, o.s7);
+  equal(0x0, o.s8);
+  equal(0x0, o.s9);
+  equal(0x0, o.s10);
+  equal(0x0, o.s11);
+  equal(0x0, o.s12);
+  equal(0x0, o.s13);
+  equal(0x0, o.s14);
+  equal(0x0, o.s15);
+});
+
+test('int8x16 or', function() {
+  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  var o = SIMD.int8x16.or(m,n);  // or
+  equal(-1, o.s0);
+  equal(-1, o.s1);
+  equal(-1, o.s2);
+  equal(-1, o.s3);
+  equal(-1, o.s4);
+  equal(-1, o.s5);
+  equal(-1, o.s6);
+  equal(-1, o.s7);
+  equal(-1, o.s8);
+  equal(-1, o.s9);
+  equal(-1, o.s10);
+  equal(-1, o.s11);
+  equal(-1, o.s12);
+  equal(-1, o.s13);
+  equal(-1, o.s14);
+  equal(-1, o.s15);
+});
+
+test('int8x16 xor', function() {
+  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  var o = SIMD.int8x16.xor(m,n);  // xor
+  equal(-1, o.s0);
+  equal(-1, o.s1);
+  equal(-1, o.s2);
+  equal(-1, o.s3);
+  equal(-1, o.s4);
+  equal(-1, o.s5);
+  equal(-1, o.s6);
+  equal(-1, o.s7);
+  equal(-1, o.s8);
+  equal(-1, o.s9);
+  equal(-1, o.s10);
+  equal(-1, o.s11);
+  equal(-1, o.s12);
+  equal(-1, o.s13);
+  equal(-1, o.s14);
+  equal(-1, o.s15);
+  o = SIMD.int8x16.xor(m,m);  // xor
+  equal(0x0, o.s0);
+  equal(0x0, o.s1);
+  equal(0x0, o.s2);
+  equal(0x0, o.s3);
+  equal(0x0, o.s4);
+  equal(0x0, o.s5);
+  equal(0x0, o.s6);
+  equal(0x0, o.s7);
+  equal(0x0, o.s8);
+  equal(0x0, o.s9);
+  equal(0x0, o.s10);
+  equal(0x0, o.s11);
+  equal(0x0, o.s12);
+  equal(0x0, o.s13);
+  equal(0x0, o.s14);
+  equal(0x0, o.s15);
+});
+
+test('int8x16 neg', function() {
+  var m = SIMD.int8x16(16, -32, 64, -128, 256, -512, 1024, -2048, 4096, -8192, 16384, -32768, 65536, -131072, 262144, -524288);
+  m = SIMD.int8x16.neg(m);
+  equal(-16, m.s0);
+  equal(32, m.s1);
+  equal(-64, m.s2);
+  equal(-128, m.s3);
+  equal(0, m.s4);
+  equal(0, m.s5);
+  equal(0, m.s6);
+  equal(0, m.s7);
+  equal(0, m.s8);
+  equal(0, m.s9);
+  equal(0, m.s10);
+  equal(0, m.s11);
+  equal(0, m.s12);
+  equal(0, m.s13);
+  equal(0, m.s14);
+  equal(0, m.s15);
+
+  var n = SIMD.int8x16(0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff, -1, -1, -1, -1, 0x80, 0x00, 0x00, 0x00);
+  n = SIMD.int8x16.neg(n);
+  equal(0, n.s0);
+  equal(0, n.s1);
+  equal(0, n.s2);
+  equal(0, n.s3);
+  equal(-127, n.s4);
+  equal(1, n.s5);
+  equal(1, n.s6);
+  equal(1, n.s7);
+  equal(1, n.s8);
+  equal(1, n.s9);
+  equal(1, n.s10);
+  equal(1, n.s11);
+  equal(-128, n.s12);
+  equal(0, n.s13);
+  equal(0, n.s14);
+  equal(0, n.s15);
+});
+
+test('int8x16 signMask getter', function() {
+  var a = SIMD.int8x16(0x80, 0x00, 0x00, 0x00, 0x7, 0x02, 0x01, 0x00, 0xFF, 0xF0, 0xF2, 0xFc, 0x0, 0x0, 0x0, 0x0);
+  equal(0xf01, a.signMask);
+  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+  equal(0x0, b.signMask);
+  var c = SIMD.int8x16(0xFF, 0xFE, 0xF0, 0xF1, 0xF2, 0xF3, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF1, 0xF0, 0xFE);
+  equal(0xffff, c.signMask);
+});
+
+
+test('int8x16 add', function() {
+  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.int8x16.add(a, b);
+  equal(-1, c.s0);
+  equal(-1, c.s1);
+  equal(-1, c.s2);
+  equal(0x0, c.s3);
+  equal(-2, c.s4);
+  equal(-2, c.s5);
+  equal(-2, c.s6);
+  equal(-2, c.s7);
+  equal(0x7f, c.s8);
+  equal(-1, c.s9);
+  equal(-1, c.s10);
+  equal(0x0, c.s11);
+  equal(-1, c.s12);
+  equal(-1, c.s13);
+  equal(-1, c.s14);
+  equal(-1, c.s15);
+});
+
+test('int8x16 sub', function() {
+  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.int8x16.sub(a, b);
+  equal(-1, c.s0);
+  equal(-1, c.s1);
+  equal(-1, c.s2);
+  equal(-2, c.s3);
+  equal(0, c.s4);
+  equal(0, c.s5);
+  equal(0, c.s6);
+  equal(0, c.s7);
+  equal(0x7f, c.s8);
+  equal(-1, c.s9);
+  equal(-1, c.s10);
+  equal(-2, c.s11);
+  equal(1, c.s12);
+  equal(1, c.s13);
+  equal(1, c.s14);
+  equal(1, c.s15);
+});
+
+test('int8x16 mul', function() {
+  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.int8x16.mul(a, b);
+  equal(0x0, c.s0);
+  equal(0x0, c.s1);
+  equal(0x0, c.s2);
+  equal(-1, c.s3);
+  equal(1, c.s4);
+  equal(1, c.s5);
+  equal(1, c.s6);
+  equal(1, c.s7);
+  equal(0, c.s8);
+  equal(0, c.s9);
+  equal(0, c.s10);
+  equal(-1, c.s11);
+  equal(0, c.s12);
+  equal(0, c.s13);
+  equal(0, c.s14);
+  equal(0, c.s15);
+});
+
+test('int8x16 comparisons', function() {
+  var m = SIMD.int8x16(1000, 2000, 100, 1, -1000, -2000, -100, 1, 0, 0, 0, 0, -1, 1, -2, 2);
+  var n = SIMD.int8x16(-2000, 2000, 1, 100, 2000, -2000, -1, -100, -1, 1, -2, 2, 0, 0, 0, 0);
+  var cmp;
+  cmp = SIMD.int8x16.lessThan(m, n);
+  equal(-1, cmp.s0);
+  equal(0x0, cmp.s1);
+  equal(0x0, cmp.s2);
+  equal(-1, cmp.s3);
+  equal(0x0, cmp.s4);
+  equal(0x0, cmp.s5);
+  equal(-1, cmp.s6);
+  equal(0x0, cmp.s7);
+  equal(0x0, cmp.s8);
+  equal(-1, cmp.s9);
+  equal(0x0, cmp.s10);
+  equal(-1, cmp.s11);
+  equal(-1, cmp.s12);
+  equal(0x0, cmp.s13);
+  equal(-1, cmp.s14);
+  equal(0x0, cmp.s15);
+
+  cmp = SIMD.int8x16.equal(m, n);
+  equal(0x0, cmp.s0);
+  equal(-1, cmp.s1);
+  equal(0x0, cmp.s2);
+  equal(0x0, cmp.s3);
+  equal(0x0, cmp.s4);
+  equal(-1, cmp.s5);
+  equal(0x0, cmp.s6);
+  equal(0x0, cmp.s7);
+  equal(0x0, cmp.s8);
+  equal(0x0, cmp.s9);
+  equal(0x0, cmp.s10);
+  equal(0x0, cmp.s11);
+  equal(0x0, cmp.s12);
+  equal(0x0, cmp.s13);
+  equal(0x0, cmp.s14);
+  equal(0x0, cmp.s15);
+
+  cmp = SIMD.int8x16.greaterThan(m, n);
+  equal(0x0, cmp.s0);
+  equal(0x0, cmp.s1);
+  equal(-1, cmp.s2);
+  equal(0x0, cmp.s3);
+  equal(-1, cmp.s4);
+  equal(0x0, cmp.s5);
+  equal(0x0, cmp.s6);
+  equal(-1, cmp.s7);
+  equal(-1, cmp.s8);
+  equal(0x0, cmp.s9);
+  equal(-1, cmp.s10);
+  equal(0x0, cmp.s11);
+  equal(0x0, cmp.s12);
+  equal(-1, cmp.s13);
+  equal(0x0, cmp.s14);
+  equal(-1, cmp.s15);
+});
+
+test('int8x16 shiftLeftByScalar', function() {
+  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int8x16.shiftLeftByScalar(a, 1);
+  equal(b.s0, -2);
+  equal(b.s1, -2);
+  equal(b.s2, -2);
+  equal(b.s3, -2);
+  equal(b.s4, -2);
+  equal(b.s5, -2);
+  equal(b.s6, -2);
+  equal(b.s7, -2);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x02);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftLeftByScalar(a, 2);
+  equal(b.s0, -4);
+  equal(b.s1, -4);
+  equal(b.s2, -4);
+  equal(b.s3, -4);
+  equal(b.s4, -4);
+  equal(b.s5, -4);
+  equal(b.s6, -4);
+  equal(b.s7, -4);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x04);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftLeftByScalar(a, 6);
+  equal(b.s0, -64);
+  equal(b.s1, -64);
+  equal(b.s2, -64);
+  equal(b.s3, -64);
+  equal(b.s4, -64);
+  equal(b.s5, -64);
+  equal(b.s6, -64);
+  equal(b.s7, -64);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x40);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftLeftByScalar(a, 7);
+  equal(b.s0, -128);
+  equal(b.s1, -128);
+  equal(b.s2, -128);
+  equal(b.s3, -128);
+  equal(b.s4, -128);
+  equal(b.s5, -128);
+  equal(b.s6, -128);
+  equal(b.s7, -128);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, -128);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+});
+
+test('int8x16 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 1);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, -1);
+  equal(b.s3, -1);
+  equal(b.s4, 0x3f);
+  equal(b.s5, -1);
+  equal(b.s6, -1);
+  equal(b.s7, -1);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 2);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, -1);
+  equal(b.s3, -1);
+  equal(b.s4, 0x1f);
+  equal(b.s5, -1);
+  equal(b.s6, -1);
+  equal(b.s7, -1);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 6);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, -1);
+  equal(b.s3, -1);
+  equal(b.s4, 0x01);
+  equal(b.s5, -1);
+  equal(b.s6, -1);
+  equal(b.s7, -1);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 7);
+  equal(b.s0, -1);
+  equal(b.s1, -1);
+  equal(b.s2, -1);
+  equal(b.s3, -1);
+  equal(b.s4, 0x0);
+  equal(b.s5, -1);
+  equal(b.s6, -1);
+  equal(b.s7, -1);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+});
+
+test('int8x16 shiftRightLogicalByScalar', function() {
+  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+  var b;
+
+  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 1);
+  equal(b.s0, 0x7f);
+  equal(b.s1, 0x7f);
+  equal(b.s2, 0x7f);
+  equal(b.s3, 0x7f);
+  equal(b.s4, 0x3f);
+  equal(b.s5, 0x7f);
+  equal(b.s6, 0x7f);
+  equal(b.s7, 0x7f);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 2);
+  equal(b.s0, 0x3f);
+  equal(b.s1, 0x3f);
+  equal(b.s2, 0x3f);
+  equal(b.s3, 0x3f);
+  equal(b.s4, 0x1f);
+  equal(b.s5, 0x3f);
+  equal(b.s6, 0x3f);
+  equal(b.s7, 0x3f);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 6);
+  equal(b.s0, 0x03);
+  equal(b.s1, 0x03);
+  equal(b.s2, 0x03);
+  equal(b.s3, 0x03);
+  equal(b.s4, 0x01);
+  equal(b.s5, 0x03);
+  equal(b.s6, 0x03);
+  equal(b.s7, 0x03);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 7);
+  equal(b.s0, 0x01);
+  equal(b.s1, 0x01);
+  equal(b.s2, 0x01);
+  equal(b.s3, 0x01);
+  equal(b.s4, 0x00);
+  equal(b.s5, 0x01);
+  equal(b.s6, 0x01);
+  equal(b.s7, 0x01);
+  equal(b.s8, 0x00);
+  equal(b.s9, 0x00);
+  equal(b.s10, 0x00);
+  equal(b.s11, 0x00);
+  equal(b.s12, 0x00);
+  equal(b.s13, 0x00);
+  equal(b.s14, 0x00);
+  equal(b.s15, 0x00);
+});
+
+test('int8x16 select', function() {
+  var m = SIMD.int8x16.bool(true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false);
+  var t = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var f = SIMD.int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+  var s = SIMD.int8x16.select(m, t, f);
+  equal(1, s.s0);
+  equal(2, s.s1);
+  equal(3, s.s2);
+  equal(4, s.s3);
+  equal(5, s.s4);
+  equal(6, s.s5);
+  equal(7, s.s6);
+  equal(8, s.s7);
+  equal(25, s.s8);
+  equal(26, s.s9);
+  equal(27, s.s10);
+  equal(28, s.s11);
+  equal(29, s.s12);
+  equal(30, s.s13);
+  equal(31, s.s14);
+  equal(32, s.s15);
+});
+
+test('int8x16 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.int8x16.fromFloat32x4Bits(m);
+  equal(0x00, n.s0);
+  equal(0x00, n.s1);
+  equal(-128, n.s2);
+  equal(0x3f, n.s3);
+  equal(0x00, n.s4);
+  equal(0x00, n.s5);
+  equal(0x00, n.s6);
+  equal(0x40, n.s7);
+  equal(0x00, n.s8);
+  equal(0x00, n.s9);
+  equal(0x40, n.s10);
+  equal(0x40, n.s11);
+  equal(0x00, n.s12);
+  equal(0x00, n.s13);
+  equal(-128, n.s14);
+  equal(0x40, n.s15);
+});
+
 test('Float32x4Array simple', function() {
   var a = new Float32x4Array(1);
   equal(1, a.length);
@@ -3462,5 +4392,135 @@ test('DataView.setInt32x4 exceptions', function() {
   });
   throws(function () {
     v.setInt32x4(1, f4);
+  });
+});
+
+test('DataView.setInt16x8', function() {
+  var a = new Int16Array(16);
+  var b = new Int16Array(16);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt16(i * 2, i);
+  }
+  for (var i = 0; i < b.length; i+=8) {
+    v.setInt16x8(i * 2, SIMD.int16x8(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7));
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt16(i*2), v.getInt16(i*2));
+  }
+});
+
+test('DataView.setInt16x8 with littleEndian as false', function() {
+  var a = new Int16Array(16);
+  var b = new Int16Array(16);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt16(i * 2, i, false);
+  }
+  for (var i = 0; i < b.length; i+=8) {
+    v.setInt16x8(i * 2, SIMD.int16x8(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7), false);
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt16(i*2, false), v.getInt16(i*2, false));
+  }
+});
+
+
+test('DataView.setInt16x8 with littleEndian as true', function() {
+  var a = new Int16Array(16);
+  var b = new Int16Array(16);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt16(i * 2, i, true);
+  }
+  for (var i = 0; i < b.length; i+=8) {
+    v.setInt16x8(i * 2, SIMD.int16x8(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7), true);
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt16(i*2, true), v.getInt16(i*2, true));
+  }
+});
+
+test('DataView.setInt16x8 exceptions', function() {
+  var a = new Int16Array(16);
+  var v = new DataView(a.buffer);
+  var f4 = SIMD.float32x4(0, 1, 2, 3);
+  var i2 = SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7);
+  throws(function () {
+    v.setInt16x8(-1, i2);
+  });
+  throws(function () {
+    v.setInt16x8(28, i2);
+  });
+  throws(function () {
+    v.setInt16x8(1, f4);
+  });
+});
+
+test('DataView.setInt8x16', function() {
+  var a = new Int8Array(32);
+  var b = new Int8Array(32);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt8(i, i);
+  }
+  for (var i = 0; i < b.length; i+=16) {
+    v.setInt8x16(i, SIMD.int8x16(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9, i+10, i+11, i+12, i+13, i+14, i+15));
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt8(i), v.getInt8(i));
+  }
+});
+
+test('DataView.setInt8x16 with littleEndian as false', function() {
+  var a = new Int8Array(32);
+  var b = new Int8Array(32);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt8(i, i, false);
+  }
+  for (var i = 0; i < b.length; i+=16) {
+    v.setInt8x16(i, SIMD.int8x16(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9, i+10, i+11, i+12, i+13, i+14, i+15), false);
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt8(i, false), v.getInt8(i, false));
+  }
+});
+
+
+test('DataView.setInt8x16 with littleEndian as true', function() {
+  var a = new Int8Array(32);
+  var b = new Int8Array(32);
+  var u = new DataView(a.buffer);
+  var v = new DataView(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    u.setInt8(i, i, true);
+  }
+  for (var i = 0; i < b.length; i+=16) {
+    v.setInt8x16(i, SIMD.int8x16(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9, i+10, i+11, i+12, i+13, i+14, i+15), true);
+  }
+  for (var i = 0; i < a.length; i++) {
+    equal(u.getInt8(i, true), v.getInt8(i, true));
+  }
+});
+
+test('DataView.setInt8x16 exceptions', function() {
+  var a = new Int8Array(32);
+  var v = new DataView(a.buffer);
+  var f4 = SIMD.float32x4(0, 1, 2, 3);
+  var i2 = SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+  throws(function () {
+    v.setInt8x16(-1, i2);
+  });
+  throws(function () {
+    v.setInt8x16(28, i2);
+  });
+  throws(function () {
+    v.setInt8x16(1, f4);
   });
 });


### PR DESCRIPTION
This patch adds initial int16x8 and int8x16 support. It doesn't yet include support for shuffles, conversions, and a few other things; I'll address those in future commits. And, there's more work to be done on tests, though all the new functions have at least some coverage.
