### PR TITLE
Cleanup comments

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1985,7 +1985,7 @@ SIMD.int32x4.withX = function(t, x) {
 }
 
 /**
-  * param {int32x4} t An instance of int32x4.
+  * @param {int32x4} t An instance of int32x4.
   * @param {integer} 32-bit value used for y lane.
   * @return {int32x4} New instance of int32x4 with the values in t and
   * y lane replaced with {y}.


### PR DESCRIPTION
This does mainly two things:
- add missing parameters in methods comments.
- make the "integer" type comment more uniform (it shows up as "int" in some places).

This will show useful for a static analyzer of mine that can generate documentation from the code directly. @johnmccutchan @PeterJensen Can you please look at it quickly? This kind of patches tends to bit-rot very fast!
