### PR TITLE
When under node, use 'global' to get the global namespace.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -5526,4 +5526,12 @@ if (typeof SIMD.Int8x16.store === "undefined") {
   }
 }
 
-})(typeof window !== "undefined" ? window : this);
+// If we're in a browser, the global namespace is named 'window'. If we're
+// in node, it's named 'global'. If we're in a shell, 'this' might work.
+})(typeof window !== "undefined"
+   ? window
+   : (typeof process === 'object' &&
+      typeof require === 'function' &&
+      typeof global === 'object')
+     ? global
+     : this);


### PR DESCRIPTION
Following up on discussion in https://github.com/tc39/ecmascript_simd/issues/220