### PR TITLE
Rewrite tests to prepare for adding more types and operations

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -566,6 +566,7 @@ var int16x8 = {
   fn: SIMD.Int16x8,
   buffer: _i16x8,
   notFn: unaryBitwiseNot,
+  view: Int16Array,
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
@@ -573,7 +574,7 @@ var int16x8 = {
         "shiftLeftByScalar", "shiftRightLogicalByScalar", "shiftRightArithmeticByScalar",
         "unsignedHorizontalSum", "unsignedAbsoluteDifference", "widenedUnsignedAbsoluteDifference",
         "addSaturate", "subSaturate",
-        "load", "store"],
+        "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
 }
 
 var int8x16 = {
@@ -586,6 +587,7 @@ var int8x16 = {
   fn: SIMD.Int8x16,
   buffer: _i8x16,
   notFn: unaryBitwiseNot,
+  view: Int8Array,
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
@@ -593,7 +595,7 @@ var int8x16 = {
         "shiftLeftByScalar", "shiftRightLogicalByScalar", "shiftRightArithmeticByScalar",
         "unsignedHorizontalSum", "unsignedAbsoluteDifference", "widenedUnsignedAbsoluteDifference",
         "addSaturate", "subSaturate",
-        "load", "store"],
+        "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
 }
 
 var bool32x4 = {

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -528,9 +528,9 @@ if (typeof SIMD.Int8x16 === "undefined" ||
 
 var float32x4 = {
   name: "Float32x4",
+  fn: SIMD.Float32x4,
   lanes: 4,
   laneSize: 4,
-  fn: SIMD.Float32x4,
   buffer: _f32x4,
   view: Float32Array,
   fns: ["check", "splat", "replaceLane", "select",
@@ -542,9 +542,9 @@ var float32x4 = {
 
 var int32x4 = {
   name: "Int32x4",
+  fn: SIMD.Int32x4,
   lanes: 4,
   laneSize: 4,
-  fn: SIMD.Int32x4,
   buffer: _i32x4,
   notFn: unaryBitwiseNot,
   view: Int32Array,
@@ -558,12 +558,12 @@ var int32x4 = {
 
 var int16x8 = {
   name: "Int16x8",
+  fn: SIMD.Int16x8,
   lanes: 8,
   laneSize: 2,
   laneMask: 0xffff,
   minVal: -0x8000,
   maxVal: 0x7fff,
-  fn: SIMD.Int16x8,
   buffer: _i16x8,
   notFn: unaryBitwiseNot,
   view: Int16Array,
@@ -579,12 +579,12 @@ var int16x8 = {
 
 var int8x16 = {
   name: "Int8x16",
+  fn: SIMD.Int8x16,
   lanes: 16,
   laneSize: 1,
   laneMask: 0xff,
   minVal: -0x80,
   maxVal: 0x7f,
-  fn: SIMD.Int8x16,
   buffer: _i8x16,
   notFn: unaryBitwiseNot,
   view: Int8Array,
@@ -600,9 +600,9 @@ var int8x16 = {
 
 var bool32x4 = {
   name: "Bool32x4",
+  fn: SIMD.Bool32x4,
   lanes: 4,
   laneSize: 4,
-  fn: SIMD.Bool32x4,
   buffer: _i32x4,
   notFn: unaryLogicalNot,
   fns: ["check", "splat", "replaceLane",
@@ -612,9 +612,9 @@ var bool32x4 = {
 
 var bool16x8 = {
   name: "Bool16x8",
+  fn: SIMD.Bool16x8,
   lanes: 8,
   laneSize: 2,
-  fn: SIMD.Bool16x8,
   buffer: _i16x8,
   notFn: unaryLogicalNot,
   fns: ["check", "splat", "replaceLane",
@@ -624,9 +624,9 @@ var bool16x8 = {
 
 var bool8x16 = {
   name: "Bool8x16",
+  fn: SIMD.Bool8x16,
   lanes: 16,
   laneSize: 1,
-  fn: SIMD.Bool8x16,
   buffer: _i8x16,
   notFn: unaryLogicalNot,
   fns: ["check", "splat", "replaceLane",
@@ -645,7 +645,6 @@ float32x4.fromBits = [int32x4, int16x8, int8x16];
 int32x4.fromBits = [float32x4, int16x8, int8x16];
 int16x8.fromBits = [float32x4, int32x4, int8x16];
 int8x16.fromBits = [float32x4, int32x4, int16x8];
-
 
 // Simd widening types.
 int16x8.wideType = int32x4;
@@ -943,7 +942,7 @@ var simdFns = {
     function(type) {
       return function(a, bits) {
         if (bits>>>0 >= type.laneSize * 8)
-          return type.fn.splat(0.0);
+          return type.fn.splat(0);
         return simdShiftOp(type, binaryShiftLeft, a, bits);
       }
     },
@@ -952,7 +951,7 @@ var simdFns = {
     function(type) {
       return function(a, bits) {
         if (bits>>>0 >= type.laneSize * 8)
-          return type.fn.splat(0.0);
+          return type.fn.splat(0);
 
         function shift(val, amount) {
           if (type.laneMask)
@@ -966,8 +965,8 @@ var simdFns = {
   shiftRightArithmeticByScalar:
     function(type) {
       return function(a, bits) {
-        if (bits>>>0 >= 32)
-          bits = 31;
+        if (bits>>>0 >= type.laneSize * 8)
+          bits = type.laneSize * 8 - 1;
         return simdShiftOp(type, binaryShiftRightArithmetic, a, bits);
       }
     },

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -44,7 +44,6 @@ if (typeof module !== "undefined") {
 
 var SIMD = global.SIMD;
 
-// private stuff.
 // Temporary buffers for swizzles and bitcasts.
 var _f32x4 = new Float32Array(4);
 var _f64x2 = new Float64Array(_f32x4.buffer);
@@ -64,7 +63,7 @@ if (typeof Math.fround !== "undefined") {
   }
 }
 
-// Type checking functions.
+// Utility functions.
 
 function isInt32(o) {
   return (o | 0) === o;
@@ -108,7 +107,7 @@ function clamp(a, min, max) {
   return a;
 }
 
-// SIMD utility functions
+// SIMD implementation functions
 
 function simdCheckLaneIndex(index, lanes) {
   if (!isInt32(index))
@@ -308,7 +307,7 @@ function binaryShiftLeft(a, bits) { return a << bits; }
 function binaryShiftRightArithmetic(a, bits) { return a >> bits; }
 
 function simdShiftOp(type, op, a, bits) {
-  // skip 'check'; Shift functions check their arguments.
+  a = type.fn.check(a);
   var lanes = [];
   for (var i = 0; i < type.lanes; i++)
     lanes[i] = op(type.fn.extractLane(a, i), bits);
@@ -555,7 +554,6 @@ var int32x4 = {
         "add", "sub", "mul", "neg", "min", "max",
         "shiftLeftByScalar", "shiftRightLogicalByScalar", "shiftRightArithmeticByScalar",
         "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
-  fromBits: ["Float32x4", "Int16x8", "Int8x16"],
 }
 
 var int16x8 = {
@@ -640,19 +638,18 @@ float32x4.boolType = int32x4.boolType = bool32x4.boolType = bool32x4;
 int16x8.boolType = bool16x8.boolType = bool16x8;
 int8x16.boolType = bool8x16.boolType = bool8x16;
 
-// SIMD from*Bits function map.
+// SIMD fromBits types.
 float32x4.fromBits = [int32x4, int16x8, int8x16];
 int32x4.fromBits = [float32x4, int16x8, int8x16];
 int16x8.fromBits = [float32x4, int32x4, int8x16];
 int8x16.fromBits = [float32x4, int32x4, int16x8];
 
 
-// Some SIMD types have widened types.
+// Simd widening types.
 int16x8.wideType = int32x4;
 int8x16.wideType = int16x8;
 
 // SIMD prototype functions.
-
 var prototypeFns = {
   valueOf:
     function(type) {
@@ -943,7 +940,6 @@ var simdFns = {
   shiftLeftByScalar:
     function(type) {
       return function(a, bits) {
-        a = type.fn.check(a);
         if (bits>>>0 >= type.laneSize * 8)
           return type.fn.splat(0.0);
         return simdShiftOp(type, binaryShiftLeft, a, bits);
@@ -953,7 +949,6 @@ var simdFns = {
   shiftRightLogicalByScalar:
     function(type) {
       return function(a, bits) {
-        a = type.fn.check(a);
         if (bits>>>0 >= type.laneSize * 8)
           return type.fn.splat(0.0);
 
@@ -969,7 +964,6 @@ var simdFns = {
   shiftRightArithmeticByScalar:
     function(type) {
       return function(a, bits) {
-        a = type.fn.check(a);
         if (bits>>>0 >= 32)
           bits = 31;
         return simdShiftOp(type, binaryShiftRightArithmetic, a, bits);

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -574,7 +574,7 @@ var int16x8 = {
         "shiftLeftByScalar", "shiftRightLogicalByScalar", "shiftRightArithmeticByScalar",
         "unsignedHorizontalSum", "unsignedAbsoluteDifference", "widenedUnsignedAbsoluteDifference",
         "addSaturate", "subSaturate",
-        "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
+        "load", "store"],
 }
 
 var int8x16 = {
@@ -595,7 +595,7 @@ var int8x16 = {
         "shiftLeftByScalar", "shiftRightLogicalByScalar", "shiftRightArithmeticByScalar",
         "unsignedHorizontalSum", "unsignedAbsoluteDifference", "widenedUnsignedAbsoluteDifference",
         "addSaturate", "subSaturate",
-        "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
+        "load", "store"],
 }
 
 var bool32x4 = {

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -34,447 +34,270 @@ function isNaN(x) {
   ok(x != x);
 }
 
-test('Float32x4 operators', function() {
-    throws(function() {Number(SIMD.Float32x4(0, 1, 2, 3))});
-    throws(function() {+SIMD.Float32x4(0, 1, 2, 3)});
-    throws(function() {-SIMD.Float32x4(0, 1, 2, 3)});
-    throws(function() {~SIMD.Float32x4(0, 1, 2, 3), -1});
-    throws(function() {Math.fround(SIMD.Float32x4(0, 1, 2, 3))});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)|0});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)&0});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)^0});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)>>>0});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)>>0});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3)<<0});
-    throws(function() {(SIMD.Float32x4(0, 1, 2, 3) + SIMD.Float32x4(4, 5, 6, 7))});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) - SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) * SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) / SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) % SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) < SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) > SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) <= SIMD.Float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Float32x4(0, 1, 2, 3) >= SIMD.Float32x4(4, 5, 6, 7)});
-    equal(SIMD.Float32x4(0, 1, 2, 3).toString(), "SIMD.Float32x4(0, 1, 2, 3)");
-    equal(SIMD.Float32x4(0, 1, 2, 3).toLocaleString(), "SIMD.Float32x4(0, 1, 2, 3)");
-    throws(function() { SIMD.Float32x4(0, 1, 2, 3)(); });
-    equal(SIMD.Float32x4(0, 1, 2, 3)[0], undefined);
-    equal(SIMD.Float32x4(0, 1, 2, 3).a, undefined);
-    equal(!SIMD.Float32x4(0, 1, 2, 3), false);
-    equal(!SIMD.Float32x4(0, 0, 0, 0), false);
-    equal(SIMD.Float32x4(0, 1, 2, 3) ? 1 : 2, 1);
-    equal(SIMD.Float32x4(0, 0, 0, 0) ? 1 : 2, 1);
-});
+function minNum(x, y) {
+  return x != x ? y :
+         y != y ? x :
+         Math.min(x, y);
+}
 
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Float32x4 value semantics', function() {
-    var y = SIMD.Float32x4(0, 0, 0, 0);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
+function maxNum(x, y) {
+  return x != x ? y :
+         y != y ? x :
+         Math.max(x, y);
+}
+
+function sameValue(x, y) {
+  if (x == y)
+    return x != 0 || y != 0 || (1/x == 1/y);
+
+  return x != x && y != y;
+}
+
+function sameValueZero(x, y) {
+  if (x == y) return true;
+  return x != x & y != y;
+}
+
+var _f32x4 = new Float32Array(4);
+var _f64x2 = new Float64Array(_f32x4.buffer);
+var _i32x4 = new Int32Array(_f32x4.buffer);
+var _i16x8 = new Int16Array(_f32x4.buffer);
+var _i8x16 = new Int8Array(_f32x4.buffer);
+
+var float32x4 = {
+  name: "Float32x4",
+  fn: SIMD.Float32x4,
+  lanes: 4,
+  laneSize: 4,
+  minVal: Number.MIN_VALUE,
+  maxVal: Number.MAX_VALUE,
+  interestingValues: [0, -0, 1, -1, 1.414, Infinity, -Infinity, NaN],
+  view: Float32Array,
+  buffer: _f32x4,
+}
+
+var int32x4 = {
+  name: "Int32x4",
+  fn: SIMD.Int32x4,
+  lanes: 4,
+  laneSize: 4,
+  minVal: -0x80000000,
+  maxVal: 0x7fffffff,
+  interestingValues: [0, 1, -1, 0xFFFFFFFF, 0x7FFFFFFF, 0x80000000],
+  view: Int32Array,
+  buffer: _i32x4,
+}
+
+var int16x8 = {
+  name: "Int16x8",
+  fn: SIMD.Int16x8,
+  lanes: 8,
+  laneSize: 2,
+  laneMask: 0xffff,
+  minVal: -0x8000,
+  maxVal: 0x7fff,
+  interestingValues: [0, 1, -1, 0xFFFF, 0x7FFF, 0x8000],
+  view: Int16Array,
+  buffer: _i16x8,
+}
+
+var int8x16 = {
+  name: "Int8x16",
+  fn: SIMD.Int8x16,
+  lanes: 16,
+  laneSize: 1,
+  laneMask: 0xff,
+  minVal: -0x80,
+  maxVal: 0x7f,
+  interestingValues: [0, 1, -1, 0xFF, 0x7F, 0x80],
+  view: Int8Array,
+  buffer: _i8x16,
+}
+
+var bool32x4 = {
+  name: "Bool32x4",
+  fn: SIMD.Bool32x4,
+  lanes: 4,
+  laneSize: 4,
+  interestingValues: [true, false],
+}
+
+var bool16x8 = {
+  name: "Bool16x8",
+  fn: SIMD.Bool16x8,
+  lanes: 8,
+  laneSize: 2,
+  interestingValues: [true, false],
+}
+
+var bool8x16 = {
+  name: "Bool8x16",
+  fn: SIMD.Bool8x16,
+  lanes: 16,
+  laneSize: 1,
+  interestingValues: [true, false],
+}
+
+// Each SIMD type has a corresponding Boolean SIMD type, which is returned by
+// relational ops.
+float32x4.boolType = int32x4.boolType = bool32x4.boolType = bool32x4;
+int16x8.boolType = bool16x8.boolType = bool16x8;
+int8x16.boolType = bool8x16.boolType = bool8x16;
+
+// SIMD from types.
+float32x4.from = [int32x4];
+
+int32x4.from = [float32x4];
+int32x4.fromFn = function(x) {
+  if (x > -2147483649.0 && x < 2147483648.0)
+    return x|0;
+  return NaN;
+}
+
+// SIMD fromBits types.
+float32x4.fromBits = [int32x4, int16x8, int8x16];
+int32x4.fromBits = [float32x4, int16x8, int8x16];
+int16x8.fromBits = [float32x4, int32x4, int8x16];
+int8x16.fromBits = [float32x4, int32x4, int16x8];
+
+// Simd widening types.
+int16x8.wideType = int32x4;
+int8x16.wideType = int16x8;
+
+var floatTypes = [float32x4];
+
+var intTypes = [int32x4, int16x8, int8x16];
+
+var smallIntTypes = [int16x8, int8x16];
+
+var boolTypes = [bool32x4, bool16x8, bool8x16];
+
+var numericalTypes = [float32x4,
+                      int32x4, int16x8, int8x16];
+
+var logicalTypes = [int32x4, int16x8, int8x16,
+                    bool32x4, bool16x8, bool8x16];
+
+var allTypes = [float32x4,
+                int32x4, int16x8, int8x16,
+                bool32x4, bool16x8, bool8x16];
+
+// SIMD reference functions.
+
+function simdCoerce(type, value) {
+  if (!type.buffer) return value;  // bool.
+  type.buffer[0] = value;
+  return type.buffer[0];
+}
+
+function simdSave(type, value) {
+  for (var i = 0; i < type.lanes; i++)
+    type.buffer[i] = type.fn.extractLane(value, i);
+}
+
+// Reference implementation of toString.
+function simdToString(type, value) {
+  value = type.fn.check(value);
+  var str = "SIMD." + type.name + "(";
+  str += type.fn.extractLane(value, 0);
+  for (var i = 1; i < type.lanes; i++) {
+    str += ", " + type.fn.extractLane(value, i);
+  }
+  return str + ")";
+}
+
+// Reference implementation of toLocaleString.
+function simdToLocaleString(type, value) {
+  value = type.fn.check(value);
+  var str = "SIMD." + type.name + "(";
+  str += type.fn.extractLane(value, 0).toLocaleString();
+  for (var i = 1; i < type.lanes; i++) {
+    str += ", " + type.fn.extractLane(value, i).toLocaleString();
+  }
+  return str + ")";
+}
+
+// Utility functions.
+
+function createTestValue(type) {
+  // Create a value for testing.
+  switch (type.lanes) {
+    case 4: return type.fn(0, 1, 2, 3);
+    case 8: return type.fn(0, 1, 2, 3, 4, 5, 6, 7);
+    case 16: return type.fn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+  }
+}
+
+function createSplatValue(type, v) {
+  var result;
+  switch (type.lanes) {
+    case 4: return type.fn(v, v, v, v);
+    case 8: return type.fn(v, v, v, v, v, v, v, v);
+    case 16: return type.fn(v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v);
+  }
+}
+
+function checkValue(type, a, expect) {
+  var same = true;
+  for (var i = 0; i < type.lanes; i++) {
+    if (!sameValue(expect(i), type.fn.extractLane(a, i))) same = false;
+  }
+  if (!same) {
+    var lanes = []
+    for (var i = 0; i < type.lanes; i++) lanes.push(expect(i));
+    fail('expected SIMD.' + type.name + '(' + lanes + ') but found ' + a.toString());
+  }
+}
+
+
+// Test the constructor and splat with the given lane values.
+function testConstructor(type) {
+  equal('function', typeof type.fn);
+  equal('function', typeof type.fn.splat);
+  for (var v of type.interestingValues) {
+    var expected = simdCoerce(type, v);
+    var result = createSplatValue(type, v);
+    checkValue(type, result, function(index) { return expected; });
+    // splat.
+    result = type.fn.splat(v);
+    checkValue(type, result, function(index) { return expected; });
+  }
+}
+
+function testCheck(type) {
+  equal('function', typeof type.fn.check);
+  // Other SIMD types shouldn't check for this type.
+  var a = type.fn();
+  for (var otherType of allTypes) {
+    if (otherType === type)
+      equal(a, type.fn.check(a));
+    else
+      throws(function() { otherType.check(a); });
+  }
+  // Neither should other types.
+  for (var x of [ {}, "", 0, 1, true, false, undefined, null, NaN, Infinity]) {
+    throws(function() { type.fn.check(x); });
+  }
+}
+
+function testReplaceLane(type) {
+  equal('function', typeof type.fn.replaceLane);
+  a = createTestValue(type);
+  for (var v of type.interestingValues) {
+    var expected = simdCoerce(type, v);
+    for (var i = 0; i < type.lanes; i++) {
+      var result = type.fn.replaceLane(a, i, v);
+      checkValue(type, result,
+                 function(index) {
+                   return index == i ? expected : type.fn.extractLane(a, index);
+                 });
     }
-    equal(y == SIMD.Float32x4(0, 0, 0, 0), true);
-    equal(y == SIMD.Float32x4(0, 0, 0, 1), false);
-    equal(y != SIMD.Float32x4(0, 0, 0, 0), false);
-    equal(y != SIMD.Float32x4(0, 0, 0, 1), true);
-    equal(y === SIMD.Float32x4(0, 0, 0, 0), true);
-    equal(y === SIMD.Float32x4(0, 0, 0, 1), false);
-    equal(y !== SIMD.Float32x4(0, 0, 0, 0), false);
-    equal(y !== SIMD.Float32x4(0, 0, 0, 1), true);
-});
-
-test('Int32x4 operators', function() {
-    throws(function() {Number(SIMD.Int32x4(0, 1, 2, 3))});
-    throws(function() {+SIMD.Int32x4(0, 1, 2, 3)});
-    throws(function() {-SIMD.Int32x4(0, 1, 2, 3)});
-    throws(function() {~SIMD.Int32x4(0, 1, 2, 3), -1});
-    throws(function() {Math.fround(SIMD.Int32x4(0, 1, 2, 3))});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)|0});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)&0});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)^0});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)>>>0});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)>>0});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3)<<0});
-    throws(function() {(SIMD.Int32x4(0, 1, 2, 3) + SIMD.Int32x4(4, 5, 6, 7))});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) - SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) * SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) / SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) % SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) < SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) > SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) <= SIMD.Int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.Int32x4(0, 1, 2, 3) >= SIMD.Int32x4(4, 5, 6, 7)});
-    equal(SIMD.Int32x4(0, 1, 2, 3).toString(), "SIMD.Int32x4(0, 1, 2, 3)");
-    equal(SIMD.Int32x4(0, 1, 2, 3).toLocaleString(), "SIMD.Int32x4(0, 1, 2, 3)");
-    throws(function() { SIMD.Int32x4(0, 1, 2, 3)(); });
-    equal(SIMD.Int32x4(0, 1, 2, 3)[0], undefined);
-    equal(SIMD.Int32x4(0, 1, 2, 3).a, undefined);
-    equal(!SIMD.Int32x4(0, 1, 2, 3), false);
-    equal(!SIMD.Int32x4(0, 0, 0, 0), false);
-    equal(SIMD.Int32x4(0, 1, 2, 3) ? 1 : 2, 1);
-    equal(SIMD.Int32x4(0, 0, 0, 0) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Int32x4 value semantics', function() {
-    var y = SIMD.Int32x4(0, 0, 0, 0);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Int32x4(0, 0, 0, 0), true);
-    equal(y == SIMD.Int32x4(0, 0, 0, 1), false);
-    equal(y != SIMD.Int32x4(0, 0, 0, 0), false);
-    equal(y != SIMD.Int32x4(0, 0, 0, 1), true);
-    equal(y === SIMD.Int32x4(0, 0, 0, 0), true);
-    equal(y === SIMD.Int32x4(0, 0, 0, 1), false);
-    equal(y !== SIMD.Int32x4(0, 0, 0, 0), false);
-    equal(y !== SIMD.Int32x4(0, 0, 0, 1), true);
-});
-
-test('Int8x16 operators', function() {
-    throws(function() {Number(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {+SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {-SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {~SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), -1});
-    throws(function() {Math.fround(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)|0});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)&0});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)^0});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>>0});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>0});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)<<0});
-    throws(function() {(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) + SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) - SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) * SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) / SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) % SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) < SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) > SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) <= SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) >= SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toString(), "SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toLocaleString(), "SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
-    throws(function() { SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)(); });
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)[0], undefined);
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).a, undefined);
-    equal(!SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
-    equal(!SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
-    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Int8x16 value semantics', function() {
-    var y = SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), true);
-    equal(y == SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1), false);
-    equal(y != SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), false);
-    equal(y != SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1), true);
-    equal(y === SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), true);
-    equal(y === SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1), false);
-    equal(y !== SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), false);
-    equal(y !== SIMD.Int8x16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1), true);
-});
-
-test('Int16x8 operators', function() {
-    throws(function() {Number(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {+SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {-SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {~SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), -1});
-    throws(function() {Math.fround(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)|0});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)&0});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)^0});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>>0});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>0});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)<<0});
-    throws(function() {(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) + SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) - SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) * SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) / SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) % SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) < SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) > SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) <= SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) >= SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).toString(), "SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).toLocaleString(), "SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
-    throws(function() { SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)(); });
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)[0], undefined);
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).a, undefined);
-    equal(!SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
-    equal(!SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
-    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Int16x8 value semantics', function() {
-    var y = SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 0);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 0), true);
-    equal(y == SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 1), false);
-    equal(y != SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 0), false);
-    equal(y != SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 1), true);
-    equal(y === SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 0), true);
-    equal(y === SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 1), false);
-    equal(y !== SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 0), false);
-    equal(y !== SIMD.Int16x8(0, 0, 0, 0, 0, 0, 0, 1), true);
-});
-
-test('Bool32x4 operators', function() {
-    throws(function() {Number(SIMD.Bool32x4(true, false, false, true))});
-    throws(function() {+SIMD.Bool32x4(true, false, false, true)});
-    throws(function() {-SIMD.Bool32x4(true, false, false, true)});
-    throws(function() {~SIMD.Bool32x4(true, false, false, true), -1});
-    throws(function() {Math.fround(SIMD.Bool32x4(true, false, false, true))});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)|0});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)&0});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)^0});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)>>>0});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)>>0});
-    throws(function() {SIMD.Bool32x4(true, false, false, true)<<0});
-    throws(function() {(SIMD.Bool32x4(true, false, false, true) + SIMD.Bool32x4(false, true, false, true))});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) - SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) * SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) / SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) % SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) < SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) > SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) <= SIMD.Bool32x4(false, true, false, true)});
-    throws(function() {SIMD.Bool32x4(true, false, false, true) >= SIMD.Bool32x4(false, true, false, true)});
-    equal(SIMD.Bool32x4(true, false, false, true).toString(), "SIMD.Bool32x4(true, false, false, true)");
-    equal(SIMD.Bool32x4(true, false, false, true).toLocaleString(), "SIMD.Bool32x4(true, false, false, true)");
-    throws(function() { SIMD.Bool32x4(true, false, false, true)(); });
-    equal(SIMD.Bool32x4(true, false, false, true)[0], undefined);
-    equal(SIMD.Bool32x4(true, false, false, true).a, undefined);
-    equal(!SIMD.Bool32x4(true, false, false, true), false);
-    equal(!SIMD.Bool32x4(false, false, false, false), false);
-    equal(SIMD.Bool32x4(true, false, false, true) ? 1 : 2, 1);
-    equal(SIMD.Bool32x4(false, false, false, false) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Bool32x4 value semantics', function() {
-    var y = SIMD.Bool32x4(false, false, false, false);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Bool32x4(false, false, false, false), true);
-    equal(y == SIMD.Bool32x4(false, false, false, true), false);
-    equal(y != SIMD.Bool32x4(false, false, false, false), false);
-    equal(y != SIMD.Bool32x4(false, false, false, true), true);
-    equal(y === SIMD.Bool32x4(false, false, false, false), true);
-    equal(y === SIMD.Bool32x4(false, false, false, true), false);
-    equal(y !== SIMD.Bool32x4(false, false, false, false), false);
-    equal(y !== SIMD.Bool32x4(false, false, false, true), true);
-});
-
-test('Bool16x8 operators', function() {
-    throws(function() {Number(SIMD.Bool16x8(true, false, false, true, true, false, true, false))});
-    throws(function() {+SIMD.Bool16x8(true, false, false, true, true, false, true, false)});
-    throws(function() {-SIMD.Bool16x8(true, false, false, true, true, false, true, false)});
-    throws(function() {~SIMD.Bool16x8(true, false, false, true, true, false, true, false), -1});
-    throws(function() {Math.fround(SIMD.Bool16x8(true, false, false, true, true, false, true, false))});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)|0});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)&0});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)^0});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)>>>0});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)>>0});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false)<<0});
-    throws(function() {(SIMD.Bool16x8(true, false, false, true, true, false, true, false) + SIMD.Bool16x8(false, true, false, true, false, true, false, true))});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) - SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) * SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) / SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) % SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) < SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) > SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) <= SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool16x8(true, false, false, true, true, false, true, false) >= SIMD.Bool16x8(false, true, false, true, false, true, false, true)});
-    equal(SIMD.Bool16x8(true, false, false, true, true, false, true, false).toString(), "SIMD.Bool16x8(true, false, false, true, true, false, true, false)");
-    equal(SIMD.Bool16x8(true, false, false, true, true, false, true, false).toLocaleString(), "SIMD.Bool16x8(true, false, false, true, true, false, true, false)");
-    throws(function() { SIMD.Bool16x8(true, false, false, true, true, false, true, false)(); });
-    equal(SIMD.Bool16x8(true, false, false, true, true, false, true, false)[0], undefined);
-    equal(SIMD.Bool16x8(true, false, false, true, true, false, true, false).a, undefined);
-    equal(!SIMD.Bool16x8(true, false, false, true, true, false, true, false), false);
-    equal(!SIMD.Bool16x8(false, false, false, false, false, false, false, false), false);
-    equal(SIMD.Bool16x8(true, false, false, true, true, false, true, false) ? 1 : 2, 1);
-    equal(SIMD.Bool16x8(false, false, false, false, false, false, false, false) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Bool16x8 value semantics', function() {
-    var y = SIMD.Bool16x8(false, false, false, false, false, false, false, false);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Bool16x8(false, false, false, false, false, false, false, false), true);
-    equal(y == SIMD.Bool16x8(false, false, false, false, false, false, false, true), false);
-    equal(y != SIMD.Bool16x8(false, false, false, false, false, false, false, false), false);
-    equal(y != SIMD.Bool16x8(false, false, false, false, false, false, false, true), true);
-    equal(y === SIMD.Bool16x8(false, false, false, false, false, false, false, false), true);
-    equal(y === SIMD.Bool16x8(false, false, false, false, false, false, false, true), false);
-    equal(y !== SIMD.Bool16x8(false, false, false, false, false, false, false, false), false);
-    equal(y !== SIMD.Bool16x8(false, false, false, false, false, false, false, true), true);
-});
-
-test('Bool8x16 operators', function() {
-    throws(function() {Number(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false))});
-    throws(function() {+SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)});
-    throws(function() {-SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)});
-    throws(function() {~SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false), -1});
-    throws(function() {Math.fround(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false))});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)|0});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)&0});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)^0});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)>>>0});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)>>0});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)<<0});
-    throws(function() {(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) + SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true))});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) - SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) * SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) / SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) % SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) < SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) > SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) <= SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    throws(function() {SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) >= SIMD.Bool8x16(false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true)});
-    equal(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false).toString(), "SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)");
-    equal(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false).toLocaleString(), "SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)");
-    throws(function() { SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)(); });
-    equal(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false)[0], undefined);
-    equal(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false).a, undefined);
-    equal(!SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false), false);
-    equal(!SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false), false);
-    equal(SIMD.Bool8x16(true, false, false, true, true, false, true, false, true, false, true, false, true, false, true, false) ? 1 : 2, 1);
-    equal(SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false) ? 1 : 2, 1);
-});
-
-// Note: This fails in the polyfill due to the lack of value semantics.
-test('Bool8x16 value semantics', function() {
-    var y = SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
-    for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
-        equal(y == x, false);
-        equal(x == y, false);
-        equal(y != x, true);
-        equal(x != y, true);
-        equal(y === x, false);
-        equal(x === y, false);
-        equal(y !== x, true);
-        equal(x !== y, true);
-    }
-    equal(y == SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false), true);
-    equal(y == SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true), false);
-    equal(y != SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false), false);
-    equal(y != SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true), true);
-    equal(y === SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false), true);
-    equal(y === SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true), false);
-    equal(y !== SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false), false);
-    equal(y !== SIMD.Bool8x16(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true), true);
-});
-
-
-test('Bool32x4 constructor', function() {
-  equal('function', typeof SIMD.Bool32x4);
-  var m = SIMD.Bool32x4(false, true, true, false);
-  equal(false, SIMD.Bool32x4.extractLane(m, 0));
-  equal(true, SIMD.Bool32x4.extractLane(m, 1));
-  equal(true, SIMD.Bool32x4.extractLane(m, 2));
-  equal(false, SIMD.Bool32x4.extractLane(m, 3));
-
-  throws(function() { SIMD.Bool16x8.check(m); });
-  throws(function() { SIMD.Bool8x16.check(m); });
-});
-
-test('Bool32x4 splat constructor', function() {
-  equal('function', typeof SIMD.Bool32x4.splat);
-  var m = SIMD.Bool32x4.splat(true);
-  equal(true, SIMD.Bool32x4.extractLane(m, 0));
-  equal(true, SIMD.Bool32x4.extractLane(m, 1));
-  equal(true, SIMD.Bool32x4.extractLane(m, 2));
-  equal(true, SIMD.Bool32x4.extractLane(m, 3));
-  m = SIMD.Bool32x4.splat(false);
-  equal(false, SIMD.Bool32x4.extractLane(m, 0));
-  equal(false, SIMD.Bool32x4.extractLane(m, 1));
-  equal(false, SIMD.Bool32x4.extractLane(m, 2));
-  equal(false, SIMD.Bool32x4.extractLane(m, 3));
-});
-
-test('Bool32x4 scalar getters', function() {
-  var m = SIMD.Bool32x4(true, false, true, false);
-  equal(true, SIMD.Bool32x4.extractLane(m, 0));
-  equal(false, SIMD.Bool32x4.extractLane(m, 1));
-  equal(true, SIMD.Bool32x4.extractLane(m, 2));
-  equal(false, SIMD.Bool32x4.extractLane(m, 3));
-});
-
-test('Bool32x4 replaceLane', function() {
-  var a = SIMD.Bool32x4(false, false, false, false);
-  var c = SIMD.Bool32x4.replaceLane(a, 0, true);
-  equal(true, SIMD.Bool32x4.extractLane(c, 0));
-  equal(false, SIMD.Bool32x4.extractLane(c, 1));
-  equal(false, SIMD.Bool32x4.extractLane(c, 2));
-  equal(false, SIMD.Bool32x4.extractLane(c, 3));
-  c = SIMD.Bool32x4.replaceLane(c, 3, true);
-  equal(true, SIMD.Bool32x4.extractLane(c, 0));
-  equal(false, SIMD.Bool32x4.extractLane(c, 1));
-  equal(false, SIMD.Bool32x4.extractLane(c, 2));
-  equal(true, SIMD.Bool32x4.extractLane(c, 3));
-  c = SIMD.Bool32x4.replaceLane(c, 0, false);
-  equal(false, SIMD.Bool32x4.extractLane(c, 0));
-  equal(false, SIMD.Bool32x4.extractLane(c, 1));
-  equal(false, SIMD.Bool32x4.extractLane(c, 2));
-  equal(true, SIMD.Bool32x4.extractLane(c, 3));
+  }
 
   function testIndexCheck(index) {
-    throws(function() { SIMD.Bool32x4.replaceLane(a, index, false); });
+    throws(function() { type.fn.replaceLane(a, index, 0); });
   }
+  testIndexCheck(type.lanes);
   testIndexCheck(13.37);
   testIndexCheck(null);
   testIndexCheck(undefined);
@@ -482,1362 +305,460 @@ test('Bool32x4 replaceLane', function() {
   testIndexCheck(true);
   testIndexCheck('yo');
   testIndexCheck(-1);
-  testIndexCheck(4);
-});
+  testIndexCheck(128);
+}
 
-test('Bool32x4 allTrue', function () {
-  var v00 = SIMD.Bool32x4(false, false, false, false);
-  var v01 = SIMD.Bool32x4(false, true, false, false);
-  var v10 = SIMD.Bool32x4(false, false, false, true);
-  var v11 = SIMD.Bool32x4(true, true, true, true);
-  equal(SIMD.Bool32x4.allTrue(v00), false);
-  equal(SIMD.Bool32x4.allTrue(v01), false);
-  equal(SIMD.Bool32x4.allTrue(v10), false);
-  equal(SIMD.Bool32x4.allTrue(v11), true);
-});
-
-test('Bool32x4 anyTrue', function () {
-  var v00 = SIMD.Bool32x4(false, false, false, false);
-  var v01 = SIMD.Bool32x4(false, true, false, false);
-  var v10 = SIMD.Bool32x4(false, false, false, true);
-  var v11 = SIMD.Bool32x4(true, true, true, true);
-  equal(SIMD.Bool32x4.anyTrue(v00), false);
-  equal(SIMD.Bool32x4.anyTrue(v01), true);
-  equal(SIMD.Bool32x4.anyTrue(v10), true);
-  equal(SIMD.Bool32x4.anyTrue(v11), true);
-});
-
-test('Bool32x4 and', function() {
-  var m = SIMD.Bool32x4(true, true, true, false);
-  var n = SIMD.Bool32x4(true, false, true, false);
-  var o = SIMD.Bool32x4.and(m,n);
-  equal(true, SIMD.Bool32x4.extractLane(o, 0));
-  equal(false, SIMD.Bool32x4.extractLane(o, 1));
-  equal(true, SIMD.Bool32x4.extractLane(o, 2));
-  equal(false, SIMD.Bool32x4.extractLane(o, 3));
-  m = SIMD.Bool32x4(false, false, false, true);
-  n = SIMD.Bool32x4(true, false, true, true);
-  o = SIMD.Bool32x4.and(m,n);
-  equal(false, SIMD.Bool32x4.extractLane(o, 0));
-  equal(false, SIMD.Bool32x4.extractLane(o, 1));
-  equal(false, SIMD.Bool32x4.extractLane(o, 2));
-  equal(true, SIMD.Bool32x4.extractLane(o, 3));
-});
-
-test('Bool32x4 or', function() {
-  var m = SIMD.Bool32x4(true, true, true, false);
-  var n = SIMD.Bool32x4(true, false, true, false);
-  var o = SIMD.Bool32x4.or(m,n);
-  equal(true, SIMD.Bool32x4.extractLane(o, 0));
-  equal(true, SIMD.Bool32x4.extractLane(o, 1));
-  equal(true, SIMD.Bool32x4.extractLane(o, 2));
-  equal(false, SIMD.Bool32x4.extractLane(o, 3));
-  m = SIMD.Bool32x4(false, false, false, true);
-  n = SIMD.Bool32x4(true, false, true, true);
-  o = SIMD.Bool32x4.or(m,n);
-  equal(true, SIMD.Bool32x4.extractLane(o, 0));
-  equal(false, SIMD.Bool32x4.extractLane(o, 1));
-  equal(true, SIMD.Bool32x4.extractLane(o, 2));
-  equal(true, SIMD.Bool32x4.extractLane(o, 3));
-});
-
-test('Bool32x4 xor', function() {
-  var m = SIMD.Bool32x4(true, true, true, false);
-  var n = SIMD.Bool32x4(true, false, true, false);
-  var o = SIMD.Bool32x4.xor(m,n);
-  equal(false, SIMD.Bool32x4.extractLane(o, 0));
-  equal(true, SIMD.Bool32x4.extractLane(o, 1));
-  equal(false, SIMD.Bool32x4.extractLane(o, 2));
-  equal(false, SIMD.Bool32x4.extractLane(o, 3));
-  m = SIMD.Bool32x4(false, false, false, true);
-  n = SIMD.Bool32x4(true, false, true, true);
-  o = SIMD.Bool32x4.xor(m,n);
-  equal(true, SIMD.Bool32x4.extractLane(o, 0));
-  equal(false, SIMD.Bool32x4.extractLane(o, 1));
-  equal(true, SIMD.Bool32x4.extractLane(o, 2));
-  equal(false, SIMD.Bool32x4.extractLane(o, 3));
-});
-
-test('Bool32x4 not', function() {
-  var m = SIMD.Bool32x4(true, false, true, false);
-  var o = SIMD.Bool32x4.not(m);
-  equal(false, SIMD.Bool32x4.extractLane(o, 0));
-  equal(true, SIMD.Bool32x4.extractLane(o, 1));
-  equal(false, SIMD.Bool32x4.extractLane(o, 2));
-  equal(true, SIMD.Bool32x4.extractLane(o, 3));
-});
-
-test('Bool32x4 comparisons', function() {
-  var m = SIMD.Bool32x4(true, true, false, false);
-  var n = SIMD.Bool32x4(false, true, false, true);
-  var cmp;
-
-  cmp = SIMD.Bool32x4.equal(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Bool32x4.notEqual(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
-});
-
-test('Bool16x8 constructor', function() {
-  equal('function', typeof SIMD.Bool16x8);
-  var m = SIMD.Bool16x8(false, true, true, false, true, false, true, false);
-  equal(false, SIMD.Bool16x8.extractLane(m, 0));
-  equal(true, SIMD.Bool16x8.extractLane(m, 1));
-  equal(true, SIMD.Bool16x8.extractLane(m, 2));
-  equal(false, SIMD.Bool16x8.extractLane(m, 3));
-  equal(true, SIMD.Bool16x8.extractLane(m, 4));
-  equal(false, SIMD.Bool16x8.extractLane(m, 5));
-  equal(true, SIMD.Bool16x8.extractLane(m, 6));
-  equal(false, SIMD.Bool16x8.extractLane(m, 7));
-
-  throws(function() { SIMD.Bool32x4.check(m); });
-  throws(function() { SIMD.Bool8x16.check(m); });
-});
-
-test('Bool16x8 splat constructor', function() {
-  equal('function', typeof SIMD.Bool16x8.splat);
-  var m = SIMD.Bool16x8.splat(true);
-  equal(true, SIMD.Bool16x8.extractLane(m, 0));
-  equal(true, SIMD.Bool16x8.extractLane(m, 1));
-  equal(true, SIMD.Bool16x8.extractLane(m, 2));
-  equal(true, SIMD.Bool16x8.extractLane(m, 3));
-  equal(true, SIMD.Bool16x8.extractLane(m, 4));
-  equal(true, SIMD.Bool16x8.extractLane(m, 5));
-  equal(true, SIMD.Bool16x8.extractLane(m, 6));
-  equal(true, SIMD.Bool16x8.extractLane(m, 7));
-  m = SIMD.Bool16x8.splat(false);
-  equal(false, SIMD.Bool16x8.extractLane(m, 0));
-  equal(false, SIMD.Bool16x8.extractLane(m, 1));
-  equal(false, SIMD.Bool16x8.extractLane(m, 2));
-  equal(false, SIMD.Bool16x8.extractLane(m, 3));
-  equal(false, SIMD.Bool16x8.extractLane(m, 4));
-  equal(false, SIMD.Bool16x8.extractLane(m, 5));
-  equal(false, SIMD.Bool16x8.extractLane(m, 6));
-  equal(false, SIMD.Bool16x8.extractLane(m, 7));
-});
-
-test('Bool16x8 scalar getters', function() {
-  var m = SIMD.Bool16x8(true, false, true, false, true, true, false, false);
-  equal(true, SIMD.Bool16x8.extractLane(m, 0));
-  equal(false, SIMD.Bool16x8.extractLane(m, 1));
-  equal(true, SIMD.Bool16x8.extractLane(m, 2));
-  equal(false, SIMD.Bool16x8.extractLane(m, 3));
-  equal(true, SIMD.Bool16x8.extractLane(m, 4));
-  equal(true, SIMD.Bool16x8.extractLane(m, 5));
-  equal(false, SIMD.Bool16x8.extractLane(m, 6));
-  equal(false, SIMD.Bool16x8.extractLane(m, 7));
-});
-
-test('Bool16x8 replaceLane', function() {
-  var a = SIMD.Bool16x8(false, false, false, false, false, false, false, false);
-  var c = SIMD.Bool16x8.replaceLane(a, 0, true);
-  equal(true, SIMD.Bool16x8.extractLane(c, 0));
-  equal(false, SIMD.Bool16x8.extractLane(c, 1));
-  equal(false, SIMD.Bool16x8.extractLane(c, 2));
-  equal(false, SIMD.Bool16x8.extractLane(c, 3));
-  equal(false, SIMD.Bool16x8.extractLane(c, 4));
-  equal(false, SIMD.Bool16x8.extractLane(c, 5));
-  equal(false, SIMD.Bool16x8.extractLane(c, 6));
-  equal(false, SIMD.Bool16x8.extractLane(c, 7));
-  c = SIMD.Bool16x8.replaceLane(c, 3, true);
-  equal(true, SIMD.Bool16x8.extractLane(c, 0));
-  equal(false, SIMD.Bool16x8.extractLane(c, 1));
-  equal(false, SIMD.Bool16x8.extractLane(c, 2));
-  equal(true, SIMD.Bool16x8.extractLane(c, 3));
-  equal(false, SIMD.Bool16x8.extractLane(c, 4));
-  equal(false, SIMD.Bool16x8.extractLane(c, 5));
-  equal(false, SIMD.Bool16x8.extractLane(c, 6));
-  equal(false, SIMD.Bool16x8.extractLane(c, 7));
-  c = SIMD.Bool16x8.replaceLane(c, 6, true);
-  equal(true, SIMD.Bool16x8.extractLane(c, 0));
-  equal(false, SIMD.Bool16x8.extractLane(c, 1));
-  equal(false, SIMD.Bool16x8.extractLane(c, 2));
-  equal(true, SIMD.Bool16x8.extractLane(c, 3));
-  equal(false, SIMD.Bool16x8.extractLane(c, 4));
-  equal(false, SIMD.Bool16x8.extractLane(c, 5));
-  equal(true, SIMD.Bool16x8.extractLane(c, 6));
-  equal(false, SIMD.Bool16x8.extractLane(c, 7));
-  c = SIMD.Bool16x8.replaceLane(c, 0, false);
-  equal(false, SIMD.Bool16x8.extractLane(c, 0));
-  equal(false, SIMD.Bool16x8.extractLane(c, 1));
-  equal(false, SIMD.Bool16x8.extractLane(c, 2));
-  equal(true, SIMD.Bool16x8.extractLane(c, 3));
-  equal(false, SIMD.Bool16x8.extractLane(c, 4));
-  equal(false, SIMD.Bool16x8.extractLane(c, 5));
-  equal(true, SIMD.Bool16x8.extractLane(c, 6));
-  equal(false, SIMD.Bool16x8.extractLane(c, 7));
-
-  function testIndexCheck(index) {
-    throws(function() { SIMD.Bool16x8.replaceLane(a, index, false); });
+// Compare unary op's behavior to ref op at each lane.
+function testUnaryOp(type, op, refOp) {
+  equal('function', typeof type.fn[op]);
+  for (var v of type.interestingValues) {
+    var expected = simdCoerce(type, refOp(simdCoerce(type, v)));
+    var a = type.fn.splat(v);
+    var result = type.fn[op](a);
+    checkValue(type, result, function(index) { return expected; });
   }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(8);
-});
-
-test('Bool16x8 allTrue', function () {
-  var v00 = SIMD.Bool16x8(false, false, false, false, false, false, false, false);
-  var v01 = SIMD.Bool16x8(false, true, false, false, true, true, true, true);
-  var v10 = SIMD.Bool16x8(false, false, false, true, true, true, true, true);
-  var v11 = SIMD.Bool16x8(true, true, true, true, true, true, true, true);
-  equal(SIMD.Bool16x8.allTrue(v00), false);
-  equal(SIMD.Bool16x8.allTrue(v01), false);
-  equal(SIMD.Bool16x8.allTrue(v10), false);
-  equal(SIMD.Bool16x8.allTrue(v11), true);
-});
-
-test('Bool16x8 anyTrue', function () {
-  var v00 = SIMD.Bool16x8(false, false, false, false, false, false, false, false);
-  var v01 = SIMD.Bool16x8(false, true, false, false, false, false, false, false);
-  var v10 = SIMD.Bool16x8(false, false, false, false, false, false, false, true);
-  var v11 = SIMD.Bool16x8(true, true, true, true, true, true, true, true);
-  equal(SIMD.Bool16x8.anyTrue(v00), false);
-  equal(SIMD.Bool16x8.anyTrue(v01), true);
-  equal(SIMD.Bool16x8.anyTrue(v10), true);
-  equal(SIMD.Bool16x8.anyTrue(v11), true);
-});
-
-test('Bool16x8 and', function() {
-  var m = SIMD.Bool16x8(true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool16x8(true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool16x8.and(m,n);
-  equal(true, SIMD.Bool16x8.extractLane(o, 0));
-  equal(false, SIMD.Bool16x8.extractLane(o, 1));
-  equal(true, SIMD.Bool16x8.extractLane(o, 2));
-  equal(false, SIMD.Bool16x8.extractLane(o, 3));
-  equal(false, SIMD.Bool16x8.extractLane(o, 4));
-  equal(false, SIMD.Bool16x8.extractLane(o, 5));
-  equal(false, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-  m = SIMD.Bool16x8(false, false, false, true, true, true, true, false);
-  n = SIMD.Bool16x8(true, false, true, true, false, true, false, false);
-  o = SIMD.Bool16x8.and(m,n);
-  equal(false, SIMD.Bool16x8.extractLane(o, 0));
-  equal(false, SIMD.Bool16x8.extractLane(o, 1));
-  equal(false, SIMD.Bool16x8.extractLane(o, 2));
-  equal(true, SIMD.Bool16x8.extractLane(o, 3));
-  equal(false, SIMD.Bool16x8.extractLane(o, 4));
-  equal(true, SIMD.Bool16x8.extractLane(o, 5));
-  equal(false, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-});
-
-test('Bool16x8 or', function() {
-  var m = SIMD.Bool16x8(true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool16x8(true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool16x8.or(m,n);
-  equal(true, SIMD.Bool16x8.extractLane(o, 0));
-  equal(true, SIMD.Bool16x8.extractLane(o, 1));
-  equal(true, SIMD.Bool16x8.extractLane(o, 2));
-  equal(true, SIMD.Bool16x8.extractLane(o, 3));
-  equal(true, SIMD.Bool16x8.extractLane(o, 4));
-  equal(true, SIMD.Bool16x8.extractLane(o, 5));
-  equal(false, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-  m = SIMD.Bool16x8(false, false, false, true, true, true, true, false);
-  n = SIMD.Bool16x8(true, false, true, true, false, true, false, false);
-  o = SIMD.Bool16x8.or(m,n);
-  equal(true, SIMD.Bool16x8.extractLane(o, 0));
-  equal(false, SIMD.Bool16x8.extractLane(o, 1));
-  equal(true, SIMD.Bool16x8.extractLane(o, 2));
-  equal(true, SIMD.Bool16x8.extractLane(o, 3));
-  equal(true, SIMD.Bool16x8.extractLane(o, 4));
-  equal(true, SIMD.Bool16x8.extractLane(o, 5));
-  equal(true, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-});
-
-test('Bool16x8 xor', function() {
-  var m = SIMD.Bool16x8(true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool16x8(true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool16x8.xor(m,n);
-  equal(false, SIMD.Bool16x8.extractLane(o, 0));
-  equal(true, SIMD.Bool16x8.extractLane(o, 1));
-  equal(false, SIMD.Bool16x8.extractLane(o, 2));
-  equal(true, SIMD.Bool16x8.extractLane(o, 3));
-  equal(true, SIMD.Bool16x8.extractLane(o, 4));
-  equal(true, SIMD.Bool16x8.extractLane(o, 5));
-  equal(false, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-  m = SIMD.Bool16x8(false, false, false, true, true, true, true, false);
-  n = SIMD.Bool16x8(true, false, true, true, false, true, false, false);
-  o = SIMD.Bool16x8.xor(m,n);
-  equal(true, SIMD.Bool16x8.extractLane(o, 0));
-  equal(false, SIMD.Bool16x8.extractLane(o, 1));
-  equal(true, SIMD.Bool16x8.extractLane(o, 2));
-  equal(false, SIMD.Bool16x8.extractLane(o, 3));
-  equal(true, SIMD.Bool16x8.extractLane(o, 4));
-  equal(false, SIMD.Bool16x8.extractLane(o, 5));
-  equal(true, SIMD.Bool16x8.extractLane(o, 6));
-  equal(false, SIMD.Bool16x8.extractLane(o, 7));
-});
-
-test('Bool16x8 not', function() {
-  var m = SIMD.Bool16x8(true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool16x8.not(m);
-  equal(false, SIMD.Bool16x8.extractLane(o, 0));
-  equal(true, SIMD.Bool16x8.extractLane(o, 1));
-  equal(false, SIMD.Bool16x8.extractLane(o, 2));
-  equal(true, SIMD.Bool16x8.extractLane(o, 3));
-  equal(false, SIMD.Bool16x8.extractLane(o, 4));
-  equal(false, SIMD.Bool16x8.extractLane(o, 5));
-  equal(true, SIMD.Bool16x8.extractLane(o, 6));
-  equal(true, SIMD.Bool16x8.extractLane(o, 7));
-});
-
-test('Bool16x8 comparisons', function() {
-  var m = SIMD.Bool16x8(true, true, false, false, true, true, true, true);
-  var n = SIMD.Bool16x8(false, true, false, true, false, true, false, true);
-  var cmp;
-
-  cmp = SIMD.Bool16x8.equal(m, n);
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Bool16x8.notEqual(m, n);
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
-});
-
-test('Bool8x16 constructor', function() {
-  equal('function', typeof SIMD.Bool8x16);
-  var m = SIMD.Bool8x16(false, true, true, false, true, false, true, false,
-                        true, false, false, true, false, true, false, true);
-  equal(false, SIMD.Bool8x16.extractLane(m, 0));
-  equal(true, SIMD.Bool8x16.extractLane(m, 1));
-  equal(true, SIMD.Bool8x16.extractLane(m, 2));
-  equal(false, SIMD.Bool8x16.extractLane(m, 3));
-  equal(true, SIMD.Bool8x16.extractLane(m, 4));
-  equal(false, SIMD.Bool8x16.extractLane(m, 5));
-  equal(true, SIMD.Bool8x16.extractLane(m, 6));
-  equal(false, SIMD.Bool8x16.extractLane(m, 7));
-  equal(true, SIMD.Bool8x16.extractLane(m, 8));
-  equal(false, SIMD.Bool8x16.extractLane(m, 9));
-  equal(false, SIMD.Bool8x16.extractLane(m, 10));
-  equal(true, SIMD.Bool8x16.extractLane(m, 11));
-  equal(false, SIMD.Bool8x16.extractLane(m, 12));
-  equal(true, SIMD.Bool8x16.extractLane(m, 13));
-  equal(false, SIMD.Bool8x16.extractLane(m, 14));
-  equal(true, SIMD.Bool8x16.extractLane(m, 15));
-
-  throws(function() { SIMD.Bool32x4.check(m); });
-  throws(function() { SIMD.Bool16x8.check(m); });
-});
-
-test('Bool8x16 splat constructor', function() {
-  equal('function', typeof SIMD.Bool8x16.splat);
-  var m = SIMD.Bool8x16.splat(true);
-  equal(true, SIMD.Bool8x16.extractLane(m, 0));
-  equal(true, SIMD.Bool8x16.extractLane(m, 1));
-  equal(true, SIMD.Bool8x16.extractLane(m, 2));
-  equal(true, SIMD.Bool8x16.extractLane(m, 3));
-  equal(true, SIMD.Bool8x16.extractLane(m, 4));
-  equal(true, SIMD.Bool8x16.extractLane(m, 5));
-  equal(true, SIMD.Bool8x16.extractLane(m, 6));
-  equal(true, SIMD.Bool8x16.extractLane(m, 7));
-  equal(true, SIMD.Bool8x16.extractLane(m, 8));
-  equal(true, SIMD.Bool8x16.extractLane(m, 9));
-  equal(true, SIMD.Bool8x16.extractLane(m, 10));
-  equal(true, SIMD.Bool8x16.extractLane(m, 11));
-  equal(true, SIMD.Bool8x16.extractLane(m, 12));
-  equal(true, SIMD.Bool8x16.extractLane(m, 13));
-  equal(true, SIMD.Bool8x16.extractLane(m, 14));
-  equal(true, SIMD.Bool8x16.extractLane(m, 15));
-  m = SIMD.Bool8x16.splat(false);
-  equal(false, SIMD.Bool8x16.extractLane(m, 0));
-  equal(false, SIMD.Bool8x16.extractLane(m, 1));
-  equal(false, SIMD.Bool8x16.extractLane(m, 2));
-  equal(false, SIMD.Bool8x16.extractLane(m, 3));
-  equal(false, SIMD.Bool8x16.extractLane(m, 4));
-  equal(false, SIMD.Bool8x16.extractLane(m, 5));
-  equal(false, SIMD.Bool8x16.extractLane(m, 6));
-  equal(false, SIMD.Bool8x16.extractLane(m, 7));
-  equal(false, SIMD.Bool8x16.extractLane(m, 8));
-  equal(false, SIMD.Bool8x16.extractLane(m, 9));
-  equal(false, SIMD.Bool8x16.extractLane(m, 10));
-  equal(false, SIMD.Bool8x16.extractLane(m, 11));
-  equal(false, SIMD.Bool8x16.extractLane(m, 12));
-  equal(false, SIMD.Bool8x16.extractLane(m, 13));
-  equal(false, SIMD.Bool8x16.extractLane(m, 14));
-  equal(false, SIMD.Bool8x16.extractLane(m, 15));
-});
-
-test('Bool8x16 scalar getters', function() {
-  var m = SIMD.Bool8x16(true, false, true, false, true, true, false, false,
-                        false, true, false, true, false, false, true, true);
-  equal(true, SIMD.Bool8x16.extractLane(m, 0));
-  equal(false, SIMD.Bool8x16.extractLane(m, 1));
-  equal(true, SIMD.Bool8x16.extractLane(m, 2));
-  equal(false, SIMD.Bool8x16.extractLane(m, 3));
-  equal(true, SIMD.Bool8x16.extractLane(m, 4));
-  equal(true, SIMD.Bool8x16.extractLane(m, 5));
-  equal(false, SIMD.Bool8x16.extractLane(m, 6));
-  equal(false, SIMD.Bool8x16.extractLane(m, 7));
-  equal(false, SIMD.Bool8x16.extractLane(m, 8));
-  equal(true, SIMD.Bool8x16.extractLane(m, 9));
-  equal(false, SIMD.Bool8x16.extractLane(m, 10));
-  equal(true, SIMD.Bool8x16.extractLane(m, 11));
-  equal(false, SIMD.Bool8x16.extractLane(m, 12));
-  equal(false, SIMD.Bool8x16.extractLane(m, 13));
-  equal(true, SIMD.Bool8x16.extractLane(m, 14));
-  equal(true, SIMD.Bool8x16.extractLane(m, 15));
-});
-
-test('Bool8x16 replaceLane', function() {
-  var a = SIMD.Bool8x16(false, false, false, false, false, false, false, false,
-                        false, false, false, false, false, false, false, false);
-  var c = SIMD.Bool8x16.replaceLane(a, 0, true);
-  equal(true, SIMD.Bool8x16.extractLane(c, 0));
-  equal(false, SIMD.Bool8x16.extractLane(c, 1));
-  equal(false, SIMD.Bool8x16.extractLane(c, 2));
-  equal(false, SIMD.Bool8x16.extractLane(c, 3));
-  equal(false, SIMD.Bool8x16.extractLane(c, 4));
-  equal(false, SIMD.Bool8x16.extractLane(c, 5));
-  equal(false, SIMD.Bool8x16.extractLane(c, 6));
-  equal(false, SIMD.Bool8x16.extractLane(c, 7));
-  equal(false, SIMD.Bool8x16.extractLane(c, 8));
-  equal(false, SIMD.Bool8x16.extractLane(c, 9));
-  equal(false, SIMD.Bool8x16.extractLane(c, 10));
-  equal(false, SIMD.Bool8x16.extractLane(c, 11));
-  equal(false, SIMD.Bool8x16.extractLane(c, 12));
-  equal(false, SIMD.Bool8x16.extractLane(c, 13));
-  equal(false, SIMD.Bool8x16.extractLane(c, 14));
-  equal(false, SIMD.Bool8x16.extractLane(c, 15));
-  c = SIMD.Bool8x16.replaceLane(c, 7, true);
-  equal(true, SIMD.Bool8x16.extractLane(c, 0));
-  equal(false, SIMD.Bool8x16.extractLane(c, 1));
-  equal(false, SIMD.Bool8x16.extractLane(c, 2));
-  equal(false, SIMD.Bool8x16.extractLane(c, 3));
-  equal(false, SIMD.Bool8x16.extractLane(c, 4));
-  equal(false, SIMD.Bool8x16.extractLane(c, 5));
-  equal(false, SIMD.Bool8x16.extractLane(c, 6));
-  equal(true, SIMD.Bool8x16.extractLane(c, 7));
-  equal(false, SIMD.Bool8x16.extractLane(c, 8));
-  equal(false, SIMD.Bool8x16.extractLane(c, 9));
-  equal(false, SIMD.Bool8x16.extractLane(c, 10));
-  equal(false, SIMD.Bool8x16.extractLane(c, 11));
-  equal(false, SIMD.Bool8x16.extractLane(c, 12));
-  equal(false, SIMD.Bool8x16.extractLane(c, 13));
-  equal(false, SIMD.Bool8x16.extractLane(c, 14));
-  equal(false, SIMD.Bool8x16.extractLane(c, 15));
-  c = SIMD.Bool8x16.replaceLane(c, 13, true);
-  equal(true, SIMD.Bool8x16.extractLane(c, 0));
-  equal(false, SIMD.Bool8x16.extractLane(c, 1));
-  equal(false, SIMD.Bool8x16.extractLane(c, 2));
-  equal(false, SIMD.Bool8x16.extractLane(c, 3));
-  equal(false, SIMD.Bool8x16.extractLane(c, 4));
-  equal(false, SIMD.Bool8x16.extractLane(c, 5));
-  equal(false, SIMD.Bool8x16.extractLane(c, 6));
-  equal(true, SIMD.Bool8x16.extractLane(c, 7));
-  equal(false, SIMD.Bool8x16.extractLane(c, 8));
-  equal(false, SIMD.Bool8x16.extractLane(c, 9));
-  equal(false, SIMD.Bool8x16.extractLane(c, 10));
-  equal(false, SIMD.Bool8x16.extractLane(c, 11));
-  equal(false, SIMD.Bool8x16.extractLane(c, 12));
-  equal(true, SIMD.Bool8x16.extractLane(c, 13));
-  equal(false, SIMD.Bool8x16.extractLane(c, 14));
-  equal(false, SIMD.Bool8x16.extractLane(c, 15));
-  c = SIMD.Bool8x16.replaceLane(c, 0, false);
-  equal(false, SIMD.Bool8x16.extractLane(c, 0));
-  equal(false, SIMD.Bool8x16.extractLane(c, 1));
-  equal(false, SIMD.Bool8x16.extractLane(c, 2));
-  equal(false, SIMD.Bool8x16.extractLane(c, 3));
-  equal(false, SIMD.Bool8x16.extractLane(c, 4));
-  equal(false, SIMD.Bool8x16.extractLane(c, 5));
-  equal(false, SIMD.Bool8x16.extractLane(c, 6));
-  equal(true, SIMD.Bool8x16.extractLane(c, 7));
-  equal(false, SIMD.Bool8x16.extractLane(c, 8));
-  equal(false, SIMD.Bool8x16.extractLane(c, 9));
-  equal(false, SIMD.Bool8x16.extractLane(c, 10));
-  equal(false, SIMD.Bool8x16.extractLane(c, 11));
-  equal(false, SIMD.Bool8x16.extractLane(c, 12));
-  equal(true, SIMD.Bool8x16.extractLane(c, 13));
-  equal(false, SIMD.Bool8x16.extractLane(c, 14));
-  equal(false, SIMD.Bool8x16.extractLane(c, 15));
-
-  function testIndexCheck(index) {
-    throws(function() { SIMD.Bool8x16.replaceLane(a, index, false); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(16);
-});
-
-test('Bool8x16 allTrue', function () {
-  var v00 = SIMD.Bool8x16(false, false, false, false, false, false, false, false,
-                          false, false, false, false, false, false, false, false);
-  var v01 = SIMD.Bool8x16(false, true, false, false, true, true, true, true,
-                          false, true, false, false, true, true, true, true);
-  var v10 = SIMD.Bool8x16(false, false, false, true, true, true, true, true,
-                          false, false, false, true, true, true, true, true);
-  var v11 = SIMD.Bool8x16(true, true, true, true, true, true, true, true,
-                          true, true, true, true, true, true, true, true);
-  equal(SIMD.Bool8x16.allTrue(v00), false);
-  equal(SIMD.Bool8x16.allTrue(v01), false);
-  equal(SIMD.Bool8x16.allTrue(v10), false);
-  equal(SIMD.Bool8x16.allTrue(v11), true);
-});
-
-test('Bool8x16 anyTrue', function () {
-  var v00 = SIMD.Bool8x16(false, false, false, false, false, false, false, false,
-                          false, false, false, false, false, false, false, false);
-  var v01 = SIMD.Bool8x16(false, true, false, false, true, true, true, true,
-                          false, true, false, false, true, true, true, true);
-  var v10 = SIMD.Bool8x16(false, false, false, true, true, true, true, true,
-                          false, false, false, true, true, true, true, true);
-  var v11 = SIMD.Bool8x16(true, true, true, true, true, true, true, true,
-                          true, true, true, true, true, true, true, true);
-  equal(SIMD.Bool8x16.anyTrue(v00), false);
-  equal(SIMD.Bool8x16.anyTrue(v01), true);
-  equal(SIMD.Bool8x16.anyTrue(v10), true);
-  equal(SIMD.Bool8x16.anyTrue(v11), true);
-});
-
-test('Bool8x16 and', function() {
-  var m = SIMD.Bool8x16(true, true, true, true, false, false, false, false,
-                        true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool8x16(true, false, true, false, true, true, false, false,
-                        true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool8x16.and(m,n);
-  equal(true, SIMD.Bool8x16.extractLane(o, 0));
-  equal(false, SIMD.Bool8x16.extractLane(o, 1));
-  equal(true, SIMD.Bool8x16.extractLane(o, 2));
-  equal(false, SIMD.Bool8x16.extractLane(o, 3));
-  equal(false, SIMD.Bool8x16.extractLane(o, 4));
-  equal(false, SIMD.Bool8x16.extractLane(o, 5));
-  equal(false, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(true, SIMD.Bool8x16.extractLane(o, 8));
-  equal(false, SIMD.Bool8x16.extractLane(o, 9));
-  equal(true, SIMD.Bool8x16.extractLane(o, 10));
-  equal(false, SIMD.Bool8x16.extractLane(o, 11));
-  equal(false, SIMD.Bool8x16.extractLane(o, 12));
-  equal(false, SIMD.Bool8x16.extractLane(o, 13));
-  equal(false, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-  m = SIMD.Bool8x16(false, false, false, true, true, true, true, false,
-                    false, false, false, true, true, true, true, false);
-  n = SIMD.Bool8x16(true, false, true, true, false, true, false, false,
-                    true, false, true, true, false, true, false, false);
-  o = SIMD.Bool8x16.and(m,n);
-  equal(false, SIMD.Bool8x16.extractLane(o, 0));
-  equal(false, SIMD.Bool8x16.extractLane(o, 1));
-  equal(false, SIMD.Bool8x16.extractLane(o, 2));
-  equal(true, SIMD.Bool8x16.extractLane(o, 3));
-  equal(false, SIMD.Bool8x16.extractLane(o, 4));
-  equal(true, SIMD.Bool8x16.extractLane(o, 5));
-  equal(false, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(false, SIMD.Bool8x16.extractLane(o, 8));
-  equal(false, SIMD.Bool8x16.extractLane(o, 9));
-  equal(false, SIMD.Bool8x16.extractLane(o, 10));
-  equal(true, SIMD.Bool8x16.extractLane(o, 11));
-  equal(false, SIMD.Bool8x16.extractLane(o, 12));
-  equal(true, SIMD.Bool8x16.extractLane(o, 13));
-  equal(false, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-});
-
-test('Bool8x16 or', function() {
-  var m = SIMD.Bool8x16(true, true, true, true, false, false, false, false,
-                        true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool8x16(true, false, true, false, true, true, false, false,
-                        true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool8x16.or(m,n);
-  equal(true, SIMD.Bool8x16.extractLane(o, 0));
-  equal(true, SIMD.Bool8x16.extractLane(o, 1));
-  equal(true, SIMD.Bool8x16.extractLane(o, 2));
-  equal(true, SIMD.Bool8x16.extractLane(o, 3));
-  equal(true, SIMD.Bool8x16.extractLane(o, 4));
-  equal(true, SIMD.Bool8x16.extractLane(o, 5));
-  equal(false, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(true, SIMD.Bool8x16.extractLane(o, 8));
-  equal(true, SIMD.Bool8x16.extractLane(o, 9));
-  equal(true, SIMD.Bool8x16.extractLane(o, 10));
-  equal(true, SIMD.Bool8x16.extractLane(o, 11));
-  equal(true, SIMD.Bool8x16.extractLane(o, 12));
-  equal(true, SIMD.Bool8x16.extractLane(o, 13));
-  equal(false, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-  m = SIMD.Bool8x16(false, false, false, true, true, true, true, false,
-                    false, false, false, true, true, true, true, false);
-  n = SIMD.Bool8x16(true, false, true, true, false, true, false, false,
-                    true, false, true, true, false, true, false, false);
-  o = SIMD.Bool8x16.or(m,n);
-  equal(true, SIMD.Bool8x16.extractLane(o, 0));
-  equal(false, SIMD.Bool8x16.extractLane(o, 1));
-  equal(true, SIMD.Bool8x16.extractLane(o, 2));
-  equal(true, SIMD.Bool8x16.extractLane(o, 3));
-  equal(true, SIMD.Bool8x16.extractLane(o, 4));
-  equal(true, SIMD.Bool8x16.extractLane(o, 5));
-  equal(true, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(true, SIMD.Bool8x16.extractLane(o, 8));
-  equal(false, SIMD.Bool8x16.extractLane(o, 9));
-  equal(true, SIMD.Bool8x16.extractLane(o, 10));
-  equal(true, SIMD.Bool8x16.extractLane(o, 11));
-  equal(true, SIMD.Bool8x16.extractLane(o, 12));
-  equal(true, SIMD.Bool8x16.extractLane(o, 13));
-  equal(true, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-});
-
-test('Bool8x16 xor', function() {
-  var m = SIMD.Bool8x16(true, true, true, true, false, false, false, false,
-                        true, true, true, true, false, false, false, false);
-  var n = SIMD.Bool8x16(true, false, true, false, true, true, false, false,
-                        true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool8x16.xor(m,n);
-  equal(false, SIMD.Bool8x16.extractLane(o, 0));
-  equal(true, SIMD.Bool8x16.extractLane(o, 1));
-  equal(false, SIMD.Bool8x16.extractLane(o, 2));
-  equal(true, SIMD.Bool8x16.extractLane(o, 3));
-  equal(true, SIMD.Bool8x16.extractLane(o, 4));
-  equal(true, SIMD.Bool8x16.extractLane(o, 5));
-  equal(false, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(false, SIMD.Bool8x16.extractLane(o, 8));
-  equal(true, SIMD.Bool8x16.extractLane(o, 9));
-  equal(false, SIMD.Bool8x16.extractLane(o, 10));
-  equal(true, SIMD.Bool8x16.extractLane(o, 11));
-  equal(true, SIMD.Bool8x16.extractLane(o, 12));
-  equal(true, SIMD.Bool8x16.extractLane(o, 13));
-  equal(false, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-  m = SIMD.Bool8x16(false, false, false, true, true, true, true, false,
-                    false, false, false, true, true, true, true, false);
-  n = SIMD.Bool8x16(true, false, true, true, false, true, false, false,
-                    true, false, true, true, false, true, false, false);
-  o = SIMD.Bool8x16.xor(m,n);
-  equal(true, SIMD.Bool8x16.extractLane(o, 0));
-  equal(false, SIMD.Bool8x16.extractLane(o, 1));
-  equal(true, SIMD.Bool8x16.extractLane(o, 2));
-  equal(false, SIMD.Bool8x16.extractLane(o, 3));
-  equal(true, SIMD.Bool8x16.extractLane(o, 4));
-  equal(false, SIMD.Bool8x16.extractLane(o, 5));
-  equal(true, SIMD.Bool8x16.extractLane(o, 6));
-  equal(false, SIMD.Bool8x16.extractLane(o, 7));
-  equal(true, SIMD.Bool8x16.extractLane(o, 8));
-  equal(false, SIMD.Bool8x16.extractLane(o, 9));
-  equal(true, SIMD.Bool8x16.extractLane(o, 10));
-  equal(false, SIMD.Bool8x16.extractLane(o, 11));
-  equal(true, SIMD.Bool8x16.extractLane(o, 12));
-  equal(false, SIMD.Bool8x16.extractLane(o, 13));
-  equal(true, SIMD.Bool8x16.extractLane(o, 14));
-  equal(false, SIMD.Bool8x16.extractLane(o, 15));
-});
-
-test('Bool8x16 not', function() {
-  var m = SIMD.Bool8x16(true, false, true, false, true, true, false, false,
-                        true, false, true, false, true, true, false, false);
-  var o = SIMD.Bool8x16.not(m);
-  equal(false, SIMD.Bool8x16.extractLane(o, 0));
-  equal(true, SIMD.Bool8x16.extractLane(o, 1));
-  equal(false, SIMD.Bool8x16.extractLane(o, 2));
-  equal(true, SIMD.Bool8x16.extractLane(o, 3));
-  equal(false, SIMD.Bool8x16.extractLane(o, 4));
-  equal(false, SIMD.Bool8x16.extractLane(o, 5));
-  equal(true, SIMD.Bool8x16.extractLane(o, 6));
-  equal(true, SIMD.Bool8x16.extractLane(o, 7));
-  equal(false, SIMD.Bool8x16.extractLane(o, 8));
-  equal(true, SIMD.Bool8x16.extractLane(o, 9));
-  equal(false, SIMD.Bool8x16.extractLane(o, 10));
-  equal(true, SIMD.Bool8x16.extractLane(o, 11));
-  equal(false, SIMD.Bool8x16.extractLane(o, 12));
-  equal(false, SIMD.Bool8x16.extractLane(o, 13));
-  equal(true, SIMD.Bool8x16.extractLane(o, 14));
-  equal(true, SIMD.Bool8x16.extractLane(o, 15));
-});
-
-test('Bool8x16 comparisons', function() {
-  var m = SIMD.Bool8x16(true, true, false, false, true, true, true, true,
-                        false, false, true, true, false, false, false, false);
-  var n = SIMD.Bool8x16(false, true, false, true, false, true, false, true,
-                        true, false, true, false, true, false, true, false);
-  var cmp;
-
-  cmp = SIMD.Bool8x16.equal(m, n);
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Bool8x16.notEqual(m, n);
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
-});
-
-test('Float32x4 constructor', function() {
-  notEqual(undefined, SIMD.Float32x4);  // Type.
-  notEqual(undefined, SIMD.Float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
-});
-
-test('simd128 types check', function() {
-  var x = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var a = SIMD.Float32x4.check(x);
-  equal(SIMD.Float32x4.extractLane(a, 0), SIMD.Float32x4.extractLane(x, 0));
-  equal(SIMD.Float32x4.extractLane(a, 1), SIMD.Float32x4.extractLane(x, 1));
-  equal(SIMD.Float32x4.extractLane(a, 2), SIMD.Float32x4.extractLane(x, 2));
-  equal(SIMD.Float32x4.extractLane(a, 3), SIMD.Float32x4.extractLane(x, 3));
-  throws(function() {SIMD.Float32x4.check(1)});
-  throws(function() {SIMD.Float32x4.check('hi')});
-
-  var y = SIMD.Int32x4(1, 2, 3, 4);
-  var b = SIMD.Int32x4.check(y);
-  equal(SIMD.Int32x4.extractLane(b, 0), SIMD.Int32x4.extractLane(y, 0));
-  equal(SIMD.Int32x4.extractLane(b, 1), SIMD.Int32x4.extractLane(y, 1));
-  equal(SIMD.Int32x4.extractLane(b, 2), SIMD.Int32x4.extractLane(y, 2));
-  equal(SIMD.Int32x4.extractLane(b, 3), SIMD.Int32x4.extractLane(y, 3));
-  throws(function() {SIMD.Int32x4.check(1)});
-  throws(function() {SIMD.Int32x4.check('hi')});
-
-  var u = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var d = SIMD.Int16x8.check(u);
-  equal(SIMD.Int16x8.extractLane(d, 0), SIMD.Int16x8.extractLane(u, 0));
-  equal(SIMD.Int16x8.extractLane(d, 1), SIMD.Int16x8.extractLane(u, 1));
-  equal(SIMD.Int16x8.extractLane(d, 2), SIMD.Int16x8.extractLane(u, 2));
-  equal(SIMD.Int16x8.extractLane(d, 3), SIMD.Int16x8.extractLane(u, 3));
-  equal(SIMD.Int16x8.extractLane(d, 4), SIMD.Int16x8.extractLane(u, 4));
-  equal(SIMD.Int16x8.extractLane(d, 5), SIMD.Int16x8.extractLane(u, 5));
-  equal(SIMD.Int16x8.extractLane(d, 6), SIMD.Int16x8.extractLane(u, 6));
-  equal(SIMD.Int16x8.extractLane(d, 7), SIMD.Int16x8.extractLane(u, 7));
-  throws(function() {SIMD.Int16x8.check(1)});
-  throws(function() {SIMD.Int16x8.check('hi')});
-
-  var v = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var e = SIMD.Int8x16.check(v);
-  equal(SIMD.Int8x16.extractLane(e, 0), SIMD.Int8x16.extractLane(v, 0));
-  equal(SIMD.Int8x16.extractLane(e, 1), SIMD.Int8x16.extractLane(v, 1));
-  equal(SIMD.Int8x16.extractLane(e, 2), SIMD.Int8x16.extractLane(v, 2));
-  equal(SIMD.Int8x16.extractLane(e, 3), SIMD.Int8x16.extractLane(v, 3));
-  equal(SIMD.Int8x16.extractLane(e, 4), SIMD.Int8x16.extractLane(v, 4));
-  equal(SIMD.Int8x16.extractLane(e, 5), SIMD.Int8x16.extractLane(v, 5));
-  equal(SIMD.Int8x16.extractLane(e, 6), SIMD.Int8x16.extractLane(v, 6));
-  equal(SIMD.Int8x16.extractLane(e, 7), SIMD.Int8x16.extractLane(v, 7));
-  equal(SIMD.Int8x16.extractLane(e, 8), SIMD.Int8x16.extractLane(v, 8));
-  equal(SIMD.Int8x16.extractLane(e, 9), SIMD.Int8x16.extractLane(v, 9));
-  equal(SIMD.Int8x16.extractLane(e, 10), SIMD.Int8x16.extractLane(v, 10));
-  equal(SIMD.Int8x16.extractLane(e, 11), SIMD.Int8x16.extractLane(v, 11));
-  equal(SIMD.Int8x16.extractLane(e, 12), SIMD.Int8x16.extractLane(v, 12));
-  equal(SIMD.Int8x16.extractLane(e, 13), SIMD.Int8x16.extractLane(v, 13));
-  equal(SIMD.Int8x16.extractLane(e, 14), SIMD.Int8x16.extractLane(v, 14));
-  equal(SIMD.Int8x16.extractLane(e, 15), SIMD.Int8x16.extractLane(v, 15));
-  throws(function() {SIMD.Int8x16.check(1)});
-  throws(function() {SIMD.Int8x16.check('hi')});
-});
-
-test('Float32x4 fromInt32x4 constructor', function() {
-  var m = SIMD.Int32x4(1, 2, 3, 4);
-  var n = SIMD.Float32x4.fromInt32x4(m);
-  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
-
-  m = SIMD.Int32x4(0, 2147483647, -2147483648, -1);
-  n = SIMD.Float32x4.fromInt32x4(m);
-  isPositiveZero(SIMD.Float32x4.extractLane(n, 0));
-  equal(2147483648, SIMD.Float32x4.extractLane(n, 1));
-  equal(-2147483648, SIMD.Float32x4.extractLane(n, 2));
-  equal(-1, SIMD.Float32x4.extractLane(n, 3));
-});
-
-test('Float32x4 fromInt32x4Bits constructor', function() {
-  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var n = SIMD.Float32x4.fromInt32x4Bits(m);
-  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
-});
-
-test('Float32x4 fromInt16x8Bits constructor', function() {
-  var m = SIMD.Int16x8(0x0000, 0x3F80, 0x0000, 0x4000, 0x0000, 0x4040, 0x0000, 0x4080);
-  var n = SIMD.Float32x4.fromInt16x8Bits(m);
-  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
-});
-
-test('Float32x4 fromInt8x16Bits constructor', function() {
-  var m = SIMD.Int8x16(0x0, 0x0, 0x80, 0x3F, 0x0, 0x0, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40, 0x00, 0x00, 0x80, 0x40);
-  var n = SIMD.Float32x4.fromInt8x16Bits(m);
-  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
-});
-
-test('Float32x4 extract lane', function() {
-  var a = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  equal(1.0, SIMD.Float32x4.extractLane(a, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(a, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(a, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(a, 3));
-});
-
-test('Float32x4 vector getters', function() {
-  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
-  var xxxx = SIMD.Float32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.Float32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.Float32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.Float32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.Float32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 0));
-  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 1));
-  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 3));
-  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 2));
-  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 3));
-  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 1));
-  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 2));
-  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 3));
-  equal(1.0, SIMD.Float32x4.extractLane(wwww, 0));
-  equal(1.0, SIMD.Float32x4.extractLane(wwww, 1));
-  equal(1.0, SIMD.Float32x4.extractLane(wwww, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(wwww, 3));
-  equal(1.0, SIMD.Float32x4.extractLane(wzyx, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(wzyx, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(wzyx, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(wzyx, 3));
-});
-
-test('Float32x4 abs', function() {
-  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.Float32x4.abs(a);
-  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-  c = SIMD.Float32x4.abs(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-
-  var d = SIMD.Float32x4(NaN, Infinity, 0.0, 1.0);
-  var e = SIMD.Float32x4.abs(d);
-  var f = SIMD.Float32x4(-NaN, -Infinity, -0.0, -1.0);
-  var g = SIMD.Float32x4.abs(f);
-  isNaN(SIMD.Float32x4.extractLane(e, 0))
-  equal(SIMD.Float32x4.extractLane(e, 1), Infinity);
-  isPositiveZero(SIMD.Float32x4.extractLane(e, 2));
-  equal(SIMD.Float32x4.extractLane(e, 3), 1.0);
-  isNaN(SIMD.Float32x4.extractLane(g, 0))
-  equal(SIMD.Float32x4.extractLane(g, 1), Infinity);
-  isPositiveZero(SIMD.Float32x4.extractLane(g, 2));
-  equal(SIMD.Float32x4.extractLane(g, 3), 1.0);
-});
-
-test('Float32x4 neg', function() {
-  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.Float32x4.neg(a);
-  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-  c = SIMD.Float32x4.neg(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(-4.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(-3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(-2.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(-1.0, SIMD.Float32x4.extractLane(c, 3));
-
-  var d = SIMD.Float32x4(Infinity, -Infinity, 0.0, -0.0);
-  var f = SIMD.Float32x4.neg(d);
-  equal(-Infinity, SIMD.Float32x4.extractLane(f, 0));
-  equal(Infinity, SIMD.Float32x4.extractLane(f, 1));
-  isNegativeZero(SIMD.Float32x4.extractLane(f, 2));
-  isPositiveZero(SIMD.Float32x4.extractLane(f, 3));
-
-  var g = SIMD.Float32x4.neg(SIMD.Float32x4.splat(NaN));
-  isNaN(SIMD.Float32x4.extractLane(g, 0))
-});
-
-test('Float32x4 add', function() {
-  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.Float32x4.add(a, b);
-  equal(14.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(23.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(32.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(41.0, SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 sub', function() {
-  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.Float32x4.sub(a, b);
-  equal(-6.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(-17.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(-28.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(-39.0, SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 mul', function() {
-  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.Float32x4.mul(a, b);
-  equal(40.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(60.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(60.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(40.0, SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 div', function() {
-  var a = SIMD.Float32x4(4.0, 9.0, 8.0, 1.0);
-  var b = SIMD.Float32x4(2.0, 3.0, 1.0, 0.5);
-  var c = SIMD.Float32x4.div(a, b);
-  equal(2.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(8.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
-
-  var d = SIMD.Float32x4(1.0, 0.0, Infinity, NaN);
-  var e = SIMD.Float32x4(Infinity, 0.0, Infinity, 1.0);
-  var f = SIMD.Float32x4.div(d, e);
-  isPositiveZero(SIMD.Float32x4.extractLane(f, 0));
-  isNaN(SIMD.Float32x4.extractLane(f, 1))
-  isNaN(SIMD.Float32x4.extractLane(f, 2))
-  isNaN(SIMD.Float32x4.extractLane(f, 3))
-
-  var g = SIMD.Float32x4(1.0, 1.0, -1.0, -1.0);
-  var h = SIMD.Float32x4(0.0, -0.0, 0.0, -0.0);
-  var i = SIMD.Float32x4.div(g, h);
-  equal(SIMD.Float32x4.extractLane(i, 0), Infinity);
-  equal(SIMD.Float32x4.extractLane(i, 1), -Infinity);
-  equal(SIMD.Float32x4.extractLane(i, 2), -Infinity);
-  equal(SIMD.Float32x4.extractLane(i, 3), Infinity);
-});
-
-test('Float32x4 min', function() {
-  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.Float32x4.min(a, lower);
-  equal(-20.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(30.0, SIMD.Float32x4.extractLane(c, 2));
-  isPositiveZero(SIMD.Float32x4.extractLane(c, 3));
-
-  var x = SIMD.Float32x4(-0, 0, NaN, 0);
-  var y = SIMD.Float32x4(0, -0, 0, NaN);
-  var z = SIMD.Float32x4.min(x, y);
-  isNegativeZero(SIMD.Float32x4.extractLane(z, 0));
-  isNegativeZero(SIMD.Float32x4.extractLane(z, 1));
-  isNaN(SIMD.Float32x4.extractLane(z, 2))
-  isNaN(SIMD.Float32x4.extractLane(z, 3))
-});
-
-test('Float32x4 minNum', function() {
-  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.Float32x4.minNum(a, lower);
-  equal(-20.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(30.0, SIMD.Float32x4.extractLane(c, 2));
-  isPositiveZero(SIMD.Float32x4.extractLane(c, 3));
-
-  var x = SIMD.Float32x4(-0, 0, NaN, 0);
-  var y = SIMD.Float32x4(0, -0, 0, NaN);
-  var z = SIMD.Float32x4.minNum(x, y);
-  isNegativeZero(SIMD.Float32x4.extractLane(z, 0));
-  isNegativeZero(SIMD.Float32x4.extractLane(z, 1));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 2));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 3));
-});
-
-test('Float32x4 min exceptions', function() {
-  var ok    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var notOk = 1;
-  throws(function () {
-    SIMD.Float32x4.min(ok, notOk);
-  });
-  throws(function () {
-    SIMD.Float32x4.min(notOk, ok);
-  });
-});
-
-test('Float32x4 max', function() {
-  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
-  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.Float32x4.max(a, upper);
-  equal(2.5, SIMD.Float32x4.extractLane(c, 0));
-  equal(10.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(55.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-
-  var x = SIMD.Float32x4(-0, 0, NaN, 0);
-  var y = SIMD.Float32x4(0, -0, 0, NaN);
-  var z = SIMD.Float32x4.max(x, y);
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 0));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 1));
-  isNaN(SIMD.Float32x4.extractLane(z, 2))
-  isNaN(SIMD.Float32x4.extractLane(z, 3))
-});
-
-test('Float32x4 maxNum', function() {
-  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
-  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.Float32x4.maxNum(a, upper);
-  equal(2.5, SIMD.Float32x4.extractLane(c, 0));
-  equal(10.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(55.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-
-  var x = SIMD.Float32x4(-0, 0, NaN, 0);
-  var y = SIMD.Float32x4(0, -0, 0, NaN);
-  var z = SIMD.Float32x4.maxNum(x, y);
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 0));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 1));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 2));
-  isPositiveZero(SIMD.Float32x4.extractLane(z, 3));
-});
-
-test('Float32x4 max exceptions', function() {
-  var ok    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var notOk = 1;
-  throws(function () {
-    SIMD.Float32x4.max(ok, notOk);
-  });
-  throws(function () {
-    SIMD.Float32x4.max(notOk, ok);
-  });
-});
-
-test('Float32x4 reciprocal approximation', function() {
-  var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
-  var c = SIMD.Float32x4.reciprocalApproximation(a);
-  almostEqual(0.125, SIMD.Float32x4.extractLane(c, 0));
-  almostEqual(0.250, SIMD.Float32x4.extractLane(c, 1));
-  almostEqual(0.5, SIMD.Float32x4.extractLane(c, 2));
-  almostEqual(-0.5, SIMD.Float32x4.extractLane(c, 3));
-  a = SIMD.Float32x4(NaN, Infinity, -Infinity, -0);
-  c = SIMD.Float32x4.reciprocalApproximation(a);
-  isNaN(SIMD.Float32x4.extractLane(c, 0))
-  isPositiveZero(SIMD.Float32x4.extractLane(c, 1));
-  isNegativeZero(SIMD.Float32x4.extractLane(c, 2));
-  equal(-Infinity, SIMD.Float32x4.extractLane(c, 3));
-  a = SIMD.Float32x4(0, 2.3, -4.5, 7.8);
-  c = SIMD.Float32x4.reciprocalApproximation(a);
-  equal(Infinity, SIMD.Float32x4.extractLane(c, 0));
-  almostEqual(1/SIMD.Float32x4.extractLane(a, 1), SIMD.Float32x4.extractLane(c, 1));
-  almostEqual(1/SIMD.Float32x4.extractLane(a, 2), SIMD.Float32x4.extractLane(c, 2));
-  almostEqual(1/SIMD.Float32x4.extractLane(a, 3), SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 reciprocal sqrt approximation', function() {
-  var a = SIMD.Float32x4(1.0, 0.25, 0.111111, 0.0625);
-  var c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
-  almostEqual(1.0, SIMD.Float32x4.extractLane(c, 0));
-  almostEqual(2.0, SIMD.Float32x4.extractLane(c, 1));
-  almostEqual(3.0, SIMD.Float32x4.extractLane(c, 2));
-  almostEqual(4.0, SIMD.Float32x4.extractLane(c, 3));
-  a = SIMD.Float32x4(-Infinity, Infinity, NaN, 0);
-  c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
-  isNaN(SIMD.Float32x4.extractLane(c, 0))
-  isPositiveZero(SIMD.Float32x4.extractLane(c, 1));
-  isNaN(SIMD.Float32x4.extractLane(c, 2))
-  equal(Infinity, SIMD.Float32x4.extractLane(c, 3));
-  a = SIMD.Float32x4(-0, -1, 121, 144);
-  c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
-  equal(-Infinity, SIMD.Float32x4.extractLane(c, 0));
-  isNaN(SIMD.Float32x4.extractLane(c, 1))
-  almostEqual(1/11, SIMD.Float32x4.extractLane(c, 2));
-  almostEqual(1/12, SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 sqrt', function() {
-  var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-  var c = SIMD.Float32x4.sqrt(a);
-  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-  a = SIMD.Float32x4(0.0, -0.0, Infinity, -Infinity);
-  c = SIMD.Float32x4.sqrt(a);
-  isPositiveZero(SIMD.Float32x4.extractLane(c, 0));
-  isNegativeZero(SIMD.Float32x4.extractLane(c, 1));
-  equal(Infinity, SIMD.Float32x4.extractLane(c, 2));
-  isNaN(SIMD.Float32x4.extractLane(c, 3))
-  a = SIMD.Float32x4(NaN, 2.0, 0.5, 121.0);
-  c = SIMD.Float32x4.sqrt(a);
-  isNaN(SIMD.Float32x4.extractLane(c, 0))
-  equal(Math.fround(Math.SQRT2), SIMD.Float32x4.extractLane(c, 1));
-  equal(Math.fround(Math.SQRT1_2), SIMD.Float32x4.extractLane(c, 2));
-  equal(11.0, SIMD.Float32x4.extractLane(c, 3));
-});
-
-test('Float32x4 shuffle', function() {
-  var a    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var b    = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
-  var xyxy = SIMD.Float32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.Float32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.Float32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1.0, SIMD.Float32x4.extractLane(xyxy, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(xyxy, 1));
-  equal(5.0, SIMD.Float32x4.extractLane(xyxy, 2));
-  equal(6.0, SIMD.Float32x4.extractLane(xyxy, 3));
-  equal(3.0, SIMD.Float32x4.extractLane(zwzw, 0));
-  equal(4.0, SIMD.Float32x4.extractLane(zwzw, 1));
-  equal(7.0, SIMD.Float32x4.extractLane(zwzw, 2));
-  equal(8.0, SIMD.Float32x4.extractLane(zwzw, 3));
-  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 0));
-  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 1));
-  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 2));
-  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 3));
-
-  var c = SIMD.Float32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.Float32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.Float32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1.0, SIMD.Float32x4.extractLane(c, 0));
-  equal(5.0, SIMD.Float32x4.extractLane(c, 1));
-  equal(6.0, SIMD.Float32x4.extractLane(c, 2));
-  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
-  equal(3.0, SIMD.Float32x4.extractLane(d, 0));
-  equal(7.0, SIMD.Float32x4.extractLane(d, 1));
-  equal(4.0, SIMD.Float32x4.extractLane(d, 2));
-  equal(8.0, SIMD.Float32x4.extractLane(d, 3));
-  equal(1.0, SIMD.Float32x4.extractLane(e, 0));
-  equal(5.0, SIMD.Float32x4.extractLane(e, 1));
-  equal(1.0, SIMD.Float32x4.extractLane(e, 2));
-  equal(5.0, SIMD.Float32x4.extractLane(e, 3));
-
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Float32x4.shuffle(a, b, index, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(8);
-});
-
-test('Float32x4 replaceLane', function() {
-    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.Float32x4.replaceLane(a, 0, 20.0);
-    equal(20.0, SIMD.Float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-    c = SIMD.Float32x4.replaceLane(a, 1, 20.0);
-    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
-    equal(20.0, SIMD.Float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-    c = SIMD.Float32x4.replaceLane(a, 2, 20.0);
-    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
-    equal(20.0, SIMD.Float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
-    c = SIMD.Float32x4.replaceLane(a, 3, 20.0);
-    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
-    equal(20.0, SIMD.Float32x4.extractLane(c, 3));
-
-    function testIndexCheck(index) {
-      throws(function() { SIMD.Float32x4.replaceLane(a, index, 0.0); });
+}
+
+// Compare binary op's behavior to ref op at each lane with the Cartesian
+// product of the given values.
+function testBinaryOp(type, op, refOp) {
+  equal('function', typeof type.fn[op]);
+  var zero = type.fn();
+  for (var av of type.interestingValues) {
+    for (var bv of type.interestingValues) {
+      var expected = simdCoerce(type, refOp(simdCoerce(type, av), simdCoerce(type, bv)));
+      var a = type.fn.splat(av);
+      var b = type.fn.splat(bv);
+      var result = type.fn[op](a, b);
+      checkValue(type, result, function(index) { return expected; });
     }
-    testIndexCheck(13.37);
-    testIndexCheck(null);
-    testIndexCheck(undefined);
-    testIndexCheck({});
-    testIndexCheck(true);
-    testIndexCheck('yo');
-    testIndexCheck(-1);
-    testIndexCheck(8);
-});
+  }
+}
 
-test('Float32x4 comparisons', function() {
-  var m = SIMD.Float32x4(1.0, 2.0, 0.1, 0.001);
-  var n = SIMD.Float32x4(2.0, 2.0, 0.001, 0.1);
-  var cmp;
-  cmp = SIMD.Float32x4.lessThan(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
+// Compare relational op's behavior to ref op at each lane with the Cartesian
+// product of the given values.
+function testRelationalOp(type, op, refOp) {
+  equal('function', typeof type.fn[op]);
+  var zero = type.fn();
+  for (var av of type.interestingValues) {
+    for (var bv of type.interestingValues) {
+      var expected = refOp(simdCoerce(type, av), simdCoerce(type, bv));
+      var a = type.fn.splat(av);
+      var b = type.fn.splat(bv);
+      var result = type.fn[op](a, b);
+      checkValue(type.boolType, result, function(index) { return expected; });
+    }
+  }
+}
 
-  cmp = SIMD.Float32x4.lessThanOrEqual(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
+// Compare shift op's behavior to ref op at each lane.
+function testShiftOp(type, op, refOp) {
+  equal('function', typeof type.fn[op]);
+  var zero = type.fn();
+  for (var v of type.interestingValues) {
+    var s = type.laneSize * 8;
+    for (var bits of [-1, 0, 1, 2, s - 1, s, s + 1]) {
+      var expected = simdCoerce(type, refOp(simdCoerce(type, v), bits));
+      var a = type.fn.splat(v);
+      var result = type.fn[op](a, bits);
+      checkValue(type, result, function(index) { return expected; });
+    }
+  }
+}
 
-  cmp = SIMD.Float32x4.equal(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+function testFrom(toType, fromType, name) {
+  equal('function', typeof toType.fn[name]);
+  for (var v of fromType.interestingValues) {
+    var fromValue = createSplatValue(fromType, v);
+    var expected = toType.fromFn ? toType.fromFn(v) :
+                   simdCoerce(toType, simdCoerce(fromType, v));
+    if (expected != expected) {  // NaN signals failure.
+      throws(function() { toType.fn[name](fromValue) });
+    } else {
+      var result = toType.fn[name](fromValue);
+      checkValue(toType, result, function(index) { return expected; });
+    }
+  }
+}
 
-  cmp = SIMD.Float32x4.notEqual(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
+function testFromBits(toType, fromType, name) {
+  equal('function', typeof toType.fn[name]);
+  for (var v of fromType.interestingValues) {
+    var fromValue = createSplatValue(fromType, v);
+    simdSave(fromType, fromValue);
+    var result = toType.fn[name](fromValue);
+    checkValue(toType, result, function(index) { return toType.buffer[index]; });
+  }
+}
 
-  cmp = SIMD.Float32x4.greaterThanOrEqual(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+function testAnyTrue(type) {
+  equal('function', typeof type.fn.anyTrue);
+  // All lanes 'false'.
+  var a = type.fn.splat(false);
+  ok(!type.fn.anyTrue(a));
+  // One lane 'true'.
+  for (var i = 0; i < type.lanes; i++) {
+    a = type.fn.replaceLane(a, i, true);
+    ok(type.fn.anyTrue(a));
+  }
+  // All lanes 'true'.
+  a = type.fn.splat(true);
+  ok(type.fn.anyTrue(a));
+}
 
-  cmp = SIMD.Float32x4.greaterThan(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+function testAllTrue(type) {
+  equal('function', typeof type.fn.allTrue);
+  // All lanes 'true'.
+  var a = type.fn.splat(true);
+  ok(type.fn.allTrue(a));
+  // One lane 'false'.
+  for (var i = 0; i < type.lanes; i++) {
+    a = type.fn.replaceLane(a, i, false);
+    ok(!type.fn.allTrue(a));
+  }
+  // All lanes 'false'.
+  a = type.fn.splat(false);
+  ok(!type.fn.allTrue(a));
+}
 
-  var o = SIMD.Float32x4(0.0, -0.0, 0.0, NaN);
-  var p = SIMD.Float32x4(-0.0, 0.0, NaN, 0.0);
-  cmp = SIMD.Float32x4.lessThan(o, p);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+function testSelect(type) {
+  equal('function', typeof type.fn.select);
+  // set a and b to values that are different for all numerical types.
+  var av = 1;
+  var bv = 2;
+  var a = type.fn.splat(av);
+  var b = type.fn.splat(bv);
+  // test all selectors with a single 'true' lane.
+  for (var i = 0; i < type.lanes; i++) {
+    var selector = type.boolType.fn();
+    selector = type.boolType.fn.replaceLane(selector, i, true);
+    var result = type.fn.select(selector, a, b);
+    checkValue(type, result, function(index) { return index == i ? av : bv; });
+  }
+}
 
-  cmp = SIMD.Float32x4.lessThanOrEqual(o, p);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+function testSwizzle(type) {
+  equal('function', typeof type.fn.swizzle);
+  var a = createTestValue(type);  // 0, 1, 2, 3, 4, 5, 6, ...
+  var indices = [];
+  // Identity swizzle.
+  for (var i = 0; i < type.lanes; i++) indices.push(i);
+  var result = type.fn.swizzle.apply(type.fn, [a].concat(indices));
+  checkValue(type, result, function(index) { return type.fn.extractLane(a, index); });
+  // Reverse swizzle.
+  indices.reverse();
+  var result = type.fn.swizzle.apply(type.fn, [a].concat(indices));
+  checkValue(type, result, function(index) { return type.fn.extractLane(a, type.lanes - index - 1); });
 
-  cmp = SIMD.Float32x4.equal(o, p);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+  function testIndexCheck(index) {
+    for (var i = 0; i < type.lanes; i++) {
+      var args = [a].concat(indices);
+      args[i + 1] = index;
+      throws(function() { type.fn.swizzle.apply(type.fn, args); });
+    }
+  }
+  testIndexCheck(type.lanes);
+  testIndexCheck(13.37);
+  testIndexCheck(null);
+  testIndexCheck(undefined);
+  testIndexCheck({});
+  testIndexCheck(true);
+  testIndexCheck('yo');
+  testIndexCheck(-1);
+  testIndexCheck(128);
+}
 
-  cmp = SIMD.Float32x4.notEqual(o, p);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
+function testShuffle(type) {
+  var indices = [];
+  for (var i = 0; i < type.lanes; i++) indices.push(i);
 
-  cmp = SIMD.Float32x4.greaterThanOrEqual(o, p);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
+  var a = type.fn.apply(type.fn, indices);            // 0, 1, 2, 3, 4 ...
+  var b = type.fn.add(a, type.fn.splat(type.lanes));  // lanes, lanes+1 ...
+  // All lanes from a.
+  var result = type.fn.shuffle.apply(type.fn, [a, b].concat(indices));
+  checkValue(type, result, function(index) { return type.fn.extractLane(a, index); });
+  // One lane from b.
+  for (var i = 0; i < type.lanes; i++) {
+    var args = [a, b].concat(indices);
+    args[2 + i] += type.lanes;
+    var result = type.fn.shuffle.apply(type.fn, args);
+    checkValue(type, result, function(index) {
+      var val = index == i ? b : a;
+      return type.fn.extractLane(val, index);
+    });
+  }
+  // All lanes from b.
+  for (var i = 0; i < type.lanes; i++) indices[i] += type.lanes;
+  var result = type.fn.shuffle.apply(type.fn, [a, b].concat(indices));
+  checkValue(type, result, function(index) { return type.fn.extractLane(b, index); });
 
-  cmp = SIMD.Float32x4.greaterThan(o, p);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
-});
+  function testIndexCheck(index) {
+    for (var i = 0; i < type.lanes; i++) {
+      var args = [a, b].concat(indices);
+      args[i + 2] = index;
+      throws(function() { type.fn.shuffle.apply(type.fn, args); });
+    }
+  }
+  testIndexCheck(2 * type.lanes);
+  testIndexCheck(13.37);
+  testIndexCheck(null);
+  testIndexCheck(undefined);
+  testIndexCheck({});
+  testIndexCheck(true);
+  testIndexCheck('yo');
+  testIndexCheck(-1);
+  testIndexCheck(128);
+}
 
-test('Float32x4 select', function() {
-  var m = SIMD.Bool32x4(true, true, false, false);
-  var t = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var f = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
-  var s = SIMD.Float32x4.select(m, t, f);
-  equal(1.0, SIMD.Float32x4.extractLane(s, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(s, 1));
-  equal(7.0, SIMD.Float32x4.extractLane(s, 2));
-  equal(8.0, SIMD.Float32x4.extractLane(s, 3));
-});
+function testOperators(type) {
+  var inst = createTestValue(type);
+  throws(function() { Number(inst) });
+  throws(function() { +inst });
+  throws(function() { -inst });
+  throws(function() { ~inst });
+  throws(function() { Math.fround(inst) });
+  throws(function() { inst|0} );
+  throws(function() { inst&0 });
+  throws(function() { inst^0 });
+  throws(function() { inst>>>0 });
+  throws(function() { inst>>0 });
+  throws(function() { inst<<0 });
+  throws(function() { (inst + inst) });
+  throws(function() { inst - inst });
+  throws(function() { inst * inst });
+  throws(function() { inst / inst });
+  throws(function() { inst % inst });
+  throws(function() { inst < inst });
+  throws(function() { inst > inst });
+  throws(function() { inst <= inst });
+  throws(function() { inst >= inst });
+  throws(function() { inst(); });
 
-test('Float32x4 Int32x4 bit conversion', function() {
-  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var n = SIMD.Float32x4.fromInt32x4Bits(m);
-  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
-  n = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
-  m = SIMD.Int32x4.fromFloat32x4Bits(n);
-  equal(0x40A00000, SIMD.Int32x4.extractLane(m, 0));
-  equal(0x40C00000, SIMD.Int32x4.extractLane(m, 1));
-  equal(0x40E00000, SIMD.Int32x4.extractLane(m, 2));
-  equal(0x41000000, SIMD.Int32x4.extractLane(m, 3));
-  // Flip sign using bit-wise operators.
-  n = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
-  m = SIMD.Int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
-  var nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
-  equal(-9.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(-10.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(-11.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(-12.0, SIMD.Float32x4.extractLane(n, 3));
-  nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
-  equal(9.0, SIMD.Float32x4.extractLane(n, 0));
-  equal(10.0, SIMD.Float32x4.extractLane(n, 1));
-  equal(11.0, SIMD.Float32x4.extractLane(n, 2));
-  equal(12.0, SIMD.Float32x4.extractLane(n, 3));
-  // Should stay unmodified across bit conversions
-  m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
-  var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
-  //equal(SIMD.Float32x4.extractLane(m, 0), m2SIMD.Float32x4.extractLane(m2, 0)); // FIXME: These get NaN-canonicalized
-  //equal(SIMD.Float32x4.extractLane(m, 1), m2SIMD.Float32x4.extractLane(m2, 1)); // FIXME: These get NaN-canonicalized
-  equal(SIMD.Int32x4.extractLane(m, 2), SIMD.Int32x4.extractLane(m2, 2));
-  equal(SIMD.Int32x4.extractLane(m, 3), SIMD.Int32x4.extractLane(m2, 3));
-});
+  equal(inst[0], undefined);
+  equal(inst.a, undefined);
+  equal(!inst, false);
+  equal(!inst, false);
+  equal(inst ? 1 : 2, 1);
+  equal(inst ? 1 : 2, 1);
+
+  equal('function', typeof inst.toString);
+  equal(inst.toString(), simdToString(type, inst));
+  equal('function', typeof inst.toLocaleString);
+  equal(inst.toLocaleString(), simdToLocaleString(type, inst));
+  // TODO: test valueOf?
+}
+
+// Tests value semantics for a given type.
+// TODO: more complete tests for Object wrappers, sameValue, sameValueZero, etc.
+function testValueSemantics(type) {
+  var y = createTestValue(type);
+  for (var x of [ {}, "", 0, 1, undefined, null, NaN, Infinity]) {
+      equal(y == x, false);
+      equal(x == y, false);
+      equal(y != x, true);
+      equal(x != y, true);
+      equal(y === x, false);
+      equal(x === y, false);
+      equal(y !== x, true);
+      equal(x !== y, true);
+  }
+  equal(y == type.fn(), true);
+  equal(y == type.fn(1), false);
+  equal(y != type.fn(), false);
+  equal(y != type.fn(1), true);
+  equal(y === type.fn(0), true);
+  equal(y === type.fn(1), false);
+  equal(y !== type.fn(0), false);
+  equal(y !== type.fn(1), true);
+}
+
+
+for (var type of allTypes) {
+  test(type.name + ' constructor', function() {
+    testConstructor(type);
+  });
+  test(type.name + ' check', function() {
+    testCheck(type);
+  });
+  test(type.name + ' operators', function() {
+    testOperators(type);
+  });
+  // Note: This fails in the polyfill due to the lack of value semantics.
+  test(type.name + ' value semantics', function() {
+    testValueSemantics(type);
+  });
+  test(type.name + ' replaceLane', function() {
+    testReplaceLane(type);
+  });
+  test(type.name + ' equal', function() {
+    testRelationalOp(type, 'equal', function(a, b) { return a == b; });
+  });
+  test(type.name + ' notEqual', function() {
+    testRelationalOp(type, 'notEqual', function(a, b) { return a != b; });
+  });
+}
+
+for (var type of numericalTypes) {
+  test(type.name + ' lessThan', function() {
+    testRelationalOp(type, 'lessThan', function(a, b) { return a < b; });
+  });
+  test(type.name + ' lessThanOrEqual', function() {
+    testRelationalOp(type, 'lessThanOrEqual', function(a, b) { return a <= b; });
+  });
+  test(type.name + ' greaterThan', function() {
+    testRelationalOp(type, 'greaterThan', function(a, b) { return a > b; });
+  });
+  test(type.name + ' greaterThanOrEqual', function() {
+    testRelationalOp(type, 'greaterThanOrEqual', function(a, b) { return a >= b; });
+  });
+  test(type.name + ' neg', function() {
+    testUnaryOp(type, 'neg', function(a) { return -a; });
+  });
+  test(type.name + ' add', function() {
+    testBinaryOp(type, 'add', function(a, b) { return a + b; });
+  });
+  test(type.name + ' sub', function() {
+    testBinaryOp(type, 'sub', function(a, b) { return a - b; });
+  });
+  test(type.name + ' mul', function() {
+    testBinaryOp(type, 'mul', function(a, b) { return a * b; });
+  });
+  test(type.name + ' min', function() {
+    testBinaryOp(type, 'min', Math.min);
+  });
+  test(type.name + ' max', function() {
+    testBinaryOp(type, 'max', Math.max);
+  });
+  test(type.name + ' select', function() {
+    testSelect(type);
+  });
+  test(type.name + ' swizzle', function() {
+    testSwizzle(type);
+  });
+  test(type.name + ' shuffle', function() {
+    testShuffle(type);
+  });
+}
+
+for (var type of logicalTypes) {
+  test(type.name + ' and', function() {
+    testBinaryOp(type, 'and', function(a, b) { return a & b; });
+  });
+  test(type.name + ' or', function() {
+    testBinaryOp(type, 'or', function(a, b) { return a | b; });
+  });
+  test(type.name + ' xor', function() {
+    testBinaryOp(type, 'xor', function(a, b) { return a ^ b; });
+  });
+}
+
+for (var type of floatTypes) {
+  test(type.name + ' div', function() {
+    testBinaryOp(type, 'div', function(a, b) { return a / b; });
+  });
+  test(type.name + ' abs', function() {
+    testBinaryOp(type, 'abs', Math.abs);
+  });
+  test(type.name + ' minNum', function() {
+    testBinaryOp(type, 'minNum', minNum);
+  });
+  test(type.name + ' maxNum', function() {
+    testBinaryOp(type, 'maxNum', maxNum);
+  });
+  test(type.name + ' sqrt', function() {
+    testUnaryOp(type, 'sqrt', function(a) { return Math.sqrt(a); });
+  });
+  test(type.name + ' reciprocalApproximation', function() {
+    testUnaryOp(type, 'reciprocalApproximation', function(a) { return 1 / a; });
+  });
+  test(type.name + ' reciprocalSqrtApproximation', function() {
+    testUnaryOp(type, 'reciprocalSqrtApproximation', function(a) { return 1 / Math.sqrt(a); });
+  });
+}
+
+for (var type of intTypes) {
+  test(type.name + ' not', function() {
+    testUnaryOp(type, 'not', function(a) { return ~a; });
+  });
+  test(type.name + ' shiftLeftByScalar', function() {
+    function shift(a, bits) {
+      if (bits>>>0 >= type.laneSize * 8) return 0;
+      return a << bits;
+    }
+
+    testShiftOp(type, 'shiftLeftByScalar', shift);
+  });
+  test(type.name + ' shiftRightLogicalByScalar', function() {
+    function shift(a, bits) {
+      if (bits>>>0 >= type.laneSize * 8) return 0;
+      if (type.laneMask)
+        a &= type.laneMask;
+      return a >>> bits;
+    }
+
+    testShiftOp(type, 'shiftRightLogicalByScalar', shift);
+  });
+  test(type.name + ' shiftRightArithmeticByScalar', function() {
+    function shift(a, bits) {
+      if (bits>>>0 >= type.laneSize * 8)
+        bits = type.laneSize * 8 - 1;
+      return a >> bits;
+    }
+
+    testShiftOp(type, 'shiftRightArithmeticByScalar', shift);
+  });
+}
+
+for (var type of smallIntTypes) {
+  function saturate(type, a) {
+    if (a < type.minVal) return type.minVal;
+    if (a > type.maxVal) return type.maxVal;
+    return a;
+  }
+  test(type.name + ' addSaturate', function() {
+    testBinaryOp(type, 'addSaturate', function(a, b) { return simdCoerce(type, saturate(type, a + b)); });
+  });
+  test(type.name + ' subSaturate', function() {
+    testBinaryOp(type, 'subSaturate', function(a, b) { return simdCoerce(type, saturate(type, a - b)); });
+  });
+}
+
+for (var type of boolTypes) {
+  test(type.name + ' not', function() {
+    testUnaryOp(type, 'not', function(a) { return !a; });
+  });
+  test(type.name + ' anyTrue', function() {
+    testAnyTrue(type, 'anyTrue');
+  });
+  test(type.name + ' allTrue', function() {
+    testAllTrue(type, 'allTrue');
+  });
+}
+
+// From<type> functions.
+for (var type of allTypes) {
+  if (!type.from) continue;
+  for (var fromType of type.from) {
+    var fn = 'from' + fromType.name;
+    test(type.name + ' ' + fn, function() {
+      testFrom(type, fromType, fn);
+    });
+  }
+}
+
+// From<type>Bits functions.
+for (var type of allTypes) {
+  if (!type.fromBits) continue;
+  for (var fromType of type.fromBits) {
+    var fn = 'from' + fromType.name + 'Bits';
+    test(type.name + ' ' + fn, function() {
+      testFromBits(type, fromType, fn);
+    });
+  }
+}
+
+
+
 
 test('Float32x4 load', function() {
   var a = new Float32Array(8);
@@ -2389,464 +1310,6 @@ test('Float32x4 store3 exceptions', function () {
 });
 
 
-test('Int32x4 fromFloat32x4 constructor', function() {
-  var m = SIMD.Float32x4(1.0, 2.2, 3.6, 4.8);
-  var n = SIMD.Int32x4.fromFloat32x4(m);
-  equal(1, SIMD.Int32x4.extractLane(n, 0));
-  equal(2, SIMD.Int32x4.extractLane(n, 1));
-  equal(3, SIMD.Int32x4.extractLane(n, 2));
-  equal(4, SIMD.Int32x4.extractLane(n, 3));
-
-  m = SIMD.Float32x4(0.0, -0.0, -1.2, -3.8);
-  n = SIMD.Int32x4.fromFloat32x4(m);
-  equal(0, SIMD.Int32x4.extractLane(n, 0));
-  equal(0, SIMD.Int32x4.extractLane(n, 1));
-  equal(-1, SIMD.Int32x4.extractLane(n, 2));
-  equal(-3, SIMD.Int32x4.extractLane(n, 3));
-
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0x7fffffff, 0, 0, 0));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, -0x80000081, 0, 0));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, 2147483648, 0));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, 0, -2147483904));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(Infinity, 0, 0, 0));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, -Infinity, 0, 0));
-  });
-  throws(function() {
-    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, NaN, 0));
-  });
-});
-
-
-test('Int32x4 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.Int32x4.fromFloat32x4Bits(m);
-  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0));
-  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1));
-  equal(0x40400000, SIMD.Int32x4.extractLane(n, 2));
-  equal(0x40800000, SIMD.Int32x4.extractLane(n, 3));
-});
-
-test('Int32x4 swizzle', function() {
-  var a    = SIMD.Int32x4(1, 2, 3, 2147483647);
-  var xyxy = SIMD.Int32x4.swizzle(a, 0, 1, 0, 1);
-  var zwzw = SIMD.Int32x4.swizzle(a, 2, 3, 2, 3);
-  var xxxx = SIMD.Int32x4.swizzle(a, 0, 0, 0, 0);
-  equal(1, SIMD.Int32x4.extractLane(xyxy, 0));
-  equal(2, SIMD.Int32x4.extractLane(xyxy, 1));
-  equal(1, SIMD.Int32x4.extractLane(xyxy, 2));
-  equal(2, SIMD.Int32x4.extractLane(xyxy, 3));
-  equal(3, SIMD.Int32x4.extractLane(zwzw, 0));
-  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 1));
-  equal(3, SIMD.Int32x4.extractLane(zwzw, 2));
-  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 3));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 0));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 1));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 2));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 3));
-
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int32x4.swizzle(a, index, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(4);
-});
-
-test('Int32x4 shuffle', function() {
-  var a    = SIMD.Int32x4(1, 2, 3, 4);
-  var b    = SIMD.Int32x4(5, 6, 7, 2147483647);
-  var xyxy = SIMD.Int32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.Int32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.Int32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1, SIMD.Int32x4.extractLane(xyxy, 0));
-  equal(2, SIMD.Int32x4.extractLane(xyxy, 1));
-  equal(5, SIMD.Int32x4.extractLane(xyxy, 2));
-  equal(6, SIMD.Int32x4.extractLane(xyxy, 3));
-  equal(3, SIMD.Int32x4.extractLane(zwzw, 0));
-  equal(4, SIMD.Int32x4.extractLane(zwzw, 1));
-  equal(7, SIMD.Int32x4.extractLane(zwzw, 2));
-  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 3));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 0));
-  equal(1, SIMD.Int32x4.extractLane(xxxx, 1));
-  equal(5, SIMD.Int32x4.extractLane(xxxx, 2));
-  equal(5, SIMD.Int32x4.extractLane(xxxx, 3));
-
-  var c = SIMD.Int32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.Int32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.Int32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1, SIMD.Int32x4.extractLane(c, 0));
-  equal(5, SIMD.Int32x4.extractLane(c, 1));
-  equal(6, SIMD.Int32x4.extractLane(c, 2));
-  equal(2, SIMD.Int32x4.extractLane(c, 3));
-  equal(3, SIMD.Int32x4.extractLane(d, 0));
-  equal(7, SIMD.Int32x4.extractLane(d, 1));
-  equal(4, SIMD.Int32x4.extractLane(d, 2));
-  equal(2147483647, SIMD.Int32x4.extractLane(d, 3));
-  equal(1, SIMD.Int32x4.extractLane(e, 0));
-  equal(5, SIMD.Int32x4.extractLane(e, 1));
-  equal(1, SIMD.Int32x4.extractLane(e, 2));
-  equal(5, SIMD.Int32x4.extractLane(e, 3));
-
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int32x4.shuffle(a, b, index, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(8);
-});
-
-test('Int32x4 replaceLane', function() {
-    var a = SIMD.Int32x4(1, 2, 3, 4);
-    var c = SIMD.Int32x4.replaceLane(a, 0, 20);
-    equal(20, SIMD.Int32x4.extractLane(c, 0));
-    equal(2, SIMD.Int32x4.extractLane(c, 1));
-    equal(3, SIMD.Int32x4.extractLane(c, 2));
-    equal(4, SIMD.Int32x4.extractLane(c, 3));
-    c = SIMD.Int32x4.replaceLane(a, 1, 20);
-    equal(1, SIMD.Int32x4.extractLane(c, 0));
-    equal(20, SIMD.Int32x4.extractLane(c, 1));
-    equal(3, SIMD.Int32x4.extractLane(c, 2));
-    equal(4, SIMD.Int32x4.extractLane(c, 3));
-    c = SIMD.Int32x4.replaceLane(a, 2, 20);
-    equal(1, SIMD.Int32x4.extractLane(c, 0));
-    equal(2, SIMD.Int32x4.extractLane(c, 1));
-    equal(20, SIMD.Int32x4.extractLane(c, 2));
-    equal(4, SIMD.Int32x4.extractLane(c, 3));
-    c = SIMD.Int32x4.replaceLane(a, 3, 20);
-    equal(1, SIMD.Int32x4.extractLane(c, 0));
-    equal(2, SIMD.Int32x4.extractLane(c, 1));
-    equal(3, SIMD.Int32x4.extractLane(c, 2));
-    equal(20, SIMD.Int32x4.extractLane(c, 3));
-
-    function testIndexCheck(index) {
-      throws(function() { SIMD.Int32x4.replaceLane(a, index, 0.0); });
-    }
-    testIndexCheck(13.37);
-    testIndexCheck(null);
-    testIndexCheck(undefined);
-    testIndexCheck({});
-    testIndexCheck(true);
-    testIndexCheck('yo');
-    testIndexCheck(-1);
-    testIndexCheck(8);
-});
-
-test('Int32x4 and', function() {
-  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
-  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  equal(-1431655766, SIMD.Int32x4.extractLane(m, 0));
-  equal(-1431655766, SIMD.Int32x4.extractLane(m, 1));
-  equal(-1431655766, SIMD.Int32x4.extractLane(m, 2));
-  equal(-1431655766, SIMD.Int32x4.extractLane(m, 3));
-  equal(0x55555555, SIMD.Int32x4.extractLane(n, 0));
-  equal(0x55555555, SIMD.Int32x4.extractLane(n, 1));
-  equal(0x55555555, SIMD.Int32x4.extractLane(n, 2));
-  equal(0x55555555, SIMD.Int32x4.extractLane(n, 3));
-  var o = SIMD.Int32x4.and(m,n);  // and
-  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
-});
-
-test('Int32x4 or', function() {
-  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  var o = SIMD.Int32x4.or(m,n);  // or
-  equal(-1, SIMD.Int32x4.extractLane(o, 0));
-  equal(-1, SIMD.Int32x4.extractLane(o, 1));
-  equal(-1, SIMD.Int32x4.extractLane(o, 2));
-  equal(-1, SIMD.Int32x4.extractLane(o, 3));
-});
-
-test('Int32x4 xor', function() {
-  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  n = SIMD.Int32x4.replaceLane(n, 0, 0xAAAAAAAA);
-  n = SIMD.Int32x4.replaceLane(n, 1, 0xAAAAAAAA);
-  n = SIMD.Int32x4.replaceLane(n, 2, 0xAAAAAAAA);
-  n = SIMD.Int32x4.replaceLane(n, 3, 0xAAAAAAAA);
-  equal(-1431655766, SIMD.Int32x4.extractLane(n, 0));
-  equal(-1431655766, SIMD.Int32x4.extractLane(n, 1));
-  equal(-1431655766, SIMD.Int32x4.extractLane(n, 2));
-  equal(-1431655766, SIMD.Int32x4.extractLane(n, 3));
-  var o = SIMD.Int32x4.xor(m,n);  // xor
-  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
-  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
-});
-
-test('Int32x4 neg', function() {
-  var m = SIMD.Int32x4(16, -32, 64, -128);
-  m = SIMD.Int32x4.neg(m);
-  equal(-16, SIMD.Int32x4.extractLane(m, 0));
-  equal(32, SIMD.Int32x4.extractLane(m, 1));
-  equal(-64, SIMD.Int32x4.extractLane(m, 2));
-  equal(128, SIMD.Int32x4.extractLane(m, 3));
-
-  var n = SIMD.Int32x4(0, 0x7fffffff, -1, 0x80000000);
-  n = SIMD.Int32x4.neg(n);
-  equal(0, SIMD.Int32x4.extractLane(n, 0));
-  equal(-2147483647, SIMD.Int32x4.extractLane(n, 1));
-  equal(1, SIMD.Int32x4.extractLane(n, 2));
-  equal(-2147483648, SIMD.Int32x4.extractLane(n, 3));
-});
-
-test('Int32x4 vector getters', function () {
-  var a = SIMD.Int32x4(4, 3, 2, 1);
-  var xxxx = SIMD.Int32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.Int32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.Int32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.Int32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.Int32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4, SIMD.Int32x4.extractLane(xxxx, 0));
-  equal(4, SIMD.Int32x4.extractLane(xxxx, 1));
-  equal(4, SIMD.Int32x4.extractLane(xxxx, 2));
-  equal(4, SIMD.Int32x4.extractLane(xxxx, 3));
-  equal(3, SIMD.Int32x4.extractLane(yyyy, 0));
-  equal(3, SIMD.Int32x4.extractLane(yyyy, 1));
-  equal(3, SIMD.Int32x4.extractLane(yyyy, 2));
-  equal(3, SIMD.Int32x4.extractLane(yyyy, 3));
-  equal(2, SIMD.Int32x4.extractLane(zzzz, 0));
-  equal(2, SIMD.Int32x4.extractLane(zzzz, 1));
-  equal(2, SIMD.Int32x4.extractLane(zzzz, 2));
-  equal(2, SIMD.Int32x4.extractLane(zzzz, 3));
-  equal(1, SIMD.Int32x4.extractLane(wwww, 0));
-  equal(1, SIMD.Int32x4.extractLane(wwww, 1));
-  equal(1, SIMD.Int32x4.extractLane(wwww, 2));
-  equal(1, SIMD.Int32x4.extractLane(wwww, 3));
-  equal(1, SIMD.Int32x4.extractLane(wzyx, 0));
-  equal(2, SIMD.Int32x4.extractLane(wzyx, 1));
-  equal(3, SIMD.Int32x4.extractLane(wzyx, 2));
-  equal(4, SIMD.Int32x4.extractLane(wzyx, 3));
-});
-
-test('Int32x4 add', function() {
-  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
-  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.Int32x4.add(a, b);
-  equal(0x0, SIMD.Int32x4.extractLane(c, 0));
-  equal(-2, SIMD.Int32x4.extractLane(c, 1));
-  equal(-0x80000000, SIMD.Int32x4.extractLane(c, 2));
-  equal(-1, SIMD.Int32x4.extractLane(c, 3));
-});
-
-test('Int32x4 sub', function() {
-  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.Int32x4.sub(a, b);
-  equal(-2, SIMD.Int32x4.extractLane(c, 0));
-  equal(0x0, SIMD.Int32x4.extractLane(c, 1));
-  equal(0x7FFFFFFF, SIMD.Int32x4.extractLane(c, 2));
-  equal(0x1, SIMD.Int32x4.extractLane(c, 3));
-});
-
-test('Int32x4 mul', function() {
-  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
-  var c = SIMD.Int32x4.mul(a, b);
-  equal(-1, SIMD.Int32x4.extractLane(c, 0));
-  equal(0x1, SIMD.Int32x4.extractLane(c, 1));
-  equal(0x0, SIMD.Int32x4.extractLane(c, 2));
-  equal(0x0, SIMD.Int32x4.extractLane(c, 3));
-});
-
-test('Int32x4 unsignedHorizontalSum', function() {
-  var a = SIMD.Int32x4.splat(0);
-  var b = SIMD.Int32x4.unsignedHorizontalSum(a);
-  equal(0, b);
-
-  var a = SIMD.Int32x4.splat(-1);
-  var b = SIMD.Int32x4.unsignedHorizontalSum(a);
-  equal(17179869180, b);
-
-  a = SIMD.Int32x4(0xFF, 0, 0xFF, 1);
-  b = SIMD.Int32x4.unsignedHorizontalSum(a);
-  equal(511, b);
-});
-
-test('Int32x4 comparisons', function() {
-  var m = SIMD.Int32x4(1000, 2000, 100, 1);
-  var n = SIMD.Int32x4(-2000, 2000, 1, 100);
-  var cmp;
-  cmp = SIMD.Int32x4.lessThan(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Int32x4.lessThanOrEqual(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Int32x4.equal(m, n);
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Int32x4.notEqual(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Int32x4.greaterThan(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
-
-  cmp = SIMD.Int32x4.greaterThanOrEqual(m, n);
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 0));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 1));
-  equal(true, SIMD.Bool32x4.extractLane(cmp, 2));
-  equal(false, SIMD.Bool32x4.extractLane(cmp, 3));
-});
-
-test('Int32x4 shiftLeftByScalar', function() {
-  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
-  var b;
-
-  b = SIMD.Int32x4.shiftLeftByScalar(a, 1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffe|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffe|0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000002);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftLeftByScalar(a, 2);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffc|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffc|0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000004);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftLeftByScalar(a, 30);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xc0000000|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0xc0000000|0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x40000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftLeftByScalar(a, 31);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x80000000|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x80000000|0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x80000000|0);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
-  b = SIMD.Int32x4.shiftLeftByScalar(a, 32);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
-  b = SIMD.Int32x4.shiftLeftByScalar(a, -1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x0);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
-});
-
-test('Int32x4 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
-  var b;
-
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 30);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 31);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 32);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-});
-
-test('Int32x4 shiftRightLogicalByScalar', function() {
-  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
-  var b;
-
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x7fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x3fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 30);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000003);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 31);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000001);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 32);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
-});
-
-test('Int32x4 select', function() {
-  var m = SIMD.Bool32x4(true, true, false, false);
-  var t = SIMD.Int32x4(1, 2, 3, 4);
-  var f = SIMD.Int32x4(5, 6, 7, 8);
-  var s = SIMD.Int32x4.select(m, t, f);
-  equal(1, SIMD.Int32x4.extractLane(s, 0));
-  equal(2, SIMD.Int32x4.extractLane(s, 1));
-  equal(7, SIMD.Int32x4.extractLane(s, 2));
-  equal(8, SIMD.Int32x4.extractLane(s, 3));
-});
-
 test('Int32x4 load', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
@@ -3395,1607 +1858,47 @@ test('Int32x4 store3 exceptions', function () {
   });
 });
 
-test('Int16x8 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.Int16x8.fromFloat32x4Bits(m);
-  equal(0x0000, SIMD.Int16x8.extractLane(n, 0));
-  equal(0x3F80, SIMD.Int16x8.extractLane(n, 1));
-  equal(0x0000, SIMD.Int16x8.extractLane(n, 2));
-  equal(0x4000, SIMD.Int16x8.extractLane(n, 3));
-  equal(0x0000, SIMD.Int16x8.extractLane(n, 4));
-  equal(0x4040, SIMD.Int16x8.extractLane(n, 5));
-  equal(0x0000, SIMD.Int16x8.extractLane(n, 6));
-  equal(0x4080, SIMD.Int16x8.extractLane(n, 7));
+
+
+test('Float32x4 Int32x4 bit conversion', function() {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var n = SIMD.Float32x4.fromInt32x4Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
+  n = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  m = SIMD.Int32x4.fromFloat32x4Bits(n);
+  equal(0x40A00000, SIMD.Int32x4.extractLane(m, 0));
+  equal(0x40C00000, SIMD.Int32x4.extractLane(m, 1));
+  equal(0x40E00000, SIMD.Int32x4.extractLane(m, 2));
+  equal(0x41000000, SIMD.Int32x4.extractLane(m, 3));
+  // Flip sign using bit-wise operators.
+  n = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  m = SIMD.Int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  var nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
+  equal(-9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(-10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(-11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(-12.0, SIMD.Float32x4.extractLane(n, 3));
+  nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3));
+  // Should stay unmodified across bit conversions
+  m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
+  var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
+  //equal(SIMD.Float32x4.extractLane(m, 0), m2SIMD.Float32x4.extractLane(m2, 0)); // FIXME: These get NaN-canonicalized
+  //equal(SIMD.Float32x4.extractLane(m, 1), m2SIMD.Float32x4.extractLane(m2, 1)); // FIXME: These get NaN-canonicalized
+  equal(SIMD.Int32x4.extractLane(m, 2), SIMD.Int32x4.extractLane(m2, 2));
+  equal(SIMD.Int32x4.extractLane(m, 3), SIMD.Int32x4.extractLane(m2, 3));
 });
 
-test('Int16x8 swizzle', function() {
-  var a    = SIMD.Int16x8(1, 2, 3, 2147483647, 5, 6, 7, -37);
-  var xyxy = SIMD.Int16x8.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1);
-  var zwzw = SIMD.Int16x8.swizzle(a, 4, 5, 4, 5, 4, 5, 4, 5);
-  var xxxx = SIMD.Int16x8.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0);
-  equal(1, SIMD.Int16x8.extractLane(xyxy, 0));
-  equal(2, SIMD.Int16x8.extractLane(xyxy, 1));
-  equal(1, SIMD.Int16x8.extractLane(xyxy, 2));
-  equal(2, SIMD.Int16x8.extractLane(xyxy, 3));
-  equal(1, SIMD.Int16x8.extractLane(xyxy, 4));
-  equal(2, SIMD.Int16x8.extractLane(xyxy, 5));
-  equal(1, SIMD.Int16x8.extractLane(xyxy, 6));
-  equal(2, SIMD.Int16x8.extractLane(xyxy, 7));
-  equal(5, SIMD.Int16x8.extractLane(zwzw, 0));
-  equal(6, SIMD.Int16x8.extractLane(zwzw, 1));
-  equal(5, SIMD.Int16x8.extractLane(zwzw, 2));
-  equal(6, SIMD.Int16x8.extractLane(zwzw, 3));
-  equal(5, SIMD.Int16x8.extractLane(zwzw, 4));
-  equal(6, SIMD.Int16x8.extractLane(zwzw, 5));
-  equal(5, SIMD.Int16x8.extractLane(zwzw, 6));
-  equal(6, SIMD.Int16x8.extractLane(zwzw, 7));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 0));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 1));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 2));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 3));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 4));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 5));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 6));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 7));
 
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int16x8.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(8);
-});
 
-test('Int16x8 shuffle', function() {
-  var a    = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var b    = SIMD.Int16x8(9, 10, 11, 12, 13, 14, 15, 32767);
-  var xyxy = SIMD.Int16x8.shuffle(a, b, 0, 1, 2, 3, 8, 9, 10, 11);
-  var zwzw = SIMD.Int16x8.shuffle(a, b, 4, 5, 6, 7, 12, 13, 14, 15);
-  var xxxx = SIMD.Int16x8.shuffle(a, b, 0, 0, 0, 0, 8, 8, 8, 8);
-  equal(1, SIMD.Int16x8.extractLane(xyxy, 0));
-  equal(2, SIMD.Int16x8.extractLane(xyxy, 1));
-  equal(3, SIMD.Int16x8.extractLane(xyxy, 2));
-  equal(4, SIMD.Int16x8.extractLane(xyxy, 3));
-  equal(9, SIMD.Int16x8.extractLane(xyxy, 4));
-  equal(10, SIMD.Int16x8.extractLane(xyxy, 5));
-  equal(11, SIMD.Int16x8.extractLane(xyxy, 6));
-  equal(12, SIMD.Int16x8.extractLane(xyxy, 7));
-  equal(5, SIMD.Int16x8.extractLane(zwzw, 0));
-  equal(6, SIMD.Int16x8.extractLane(zwzw, 1));
-  equal(7, SIMD.Int16x8.extractLane(zwzw, 2));
-  equal(8, SIMD.Int16x8.extractLane(zwzw, 3));
-  equal(13, SIMD.Int16x8.extractLane(zwzw, 4));
-  equal(14, SIMD.Int16x8.extractLane(zwzw, 5));
-  equal(15, SIMD.Int16x8.extractLane(zwzw, 6));
-  equal(32767, SIMD.Int16x8.extractLane(zwzw, 7));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 0));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 1));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 2));
-  equal(1, SIMD.Int16x8.extractLane(xxxx, 3));
-  equal(9, SIMD.Int16x8.extractLane(xxxx, 4));
-  equal(9, SIMD.Int16x8.extractLane(xxxx, 5));
-  equal(9, SIMD.Int16x8.extractLane(xxxx, 6));
-  equal(9, SIMD.Int16x8.extractLane(xxxx, 7));
 
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int16x8.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(16);
-});
-
-test('Int16x8 and', function() {
-  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 43690, 43690, 0xAAAA, 0xAAAA);
-  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  equal(-21846, SIMD.Int16x8.extractLane(m, 0));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 1));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 2));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 3));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 4));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 5));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 6));
-  equal(-21846, SIMD.Int16x8.extractLane(m, 7));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 0));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 1));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 2));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 3));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 4));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 5));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 6));
-  equal(0x5555, SIMD.Int16x8.extractLane(n, 7));
-  var o = SIMD.Int16x8.and(m,n);  // and
-  equal(0x0, SIMD.Int16x8.extractLane(o, 0));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 1));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 2));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 3));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 4));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 5));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 6));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 7));
-});
-
-test('Int16x8 or', function() {
-  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
-  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  var o = SIMD.Int16x8.or(m,n);  // or
-  equal(-1, SIMD.Int16x8.extractLane(o, 0));
-  equal(-1, SIMD.Int16x8.extractLane(o, 1));
-  equal(-1, SIMD.Int16x8.extractLane(o, 2));
-  equal(-1, SIMD.Int16x8.extractLane(o, 3));
-  equal(-1, SIMD.Int16x8.extractLane(o, 4));
-  equal(-1, SIMD.Int16x8.extractLane(o, 5));
-  equal(-1, SIMD.Int16x8.extractLane(o, 6));
-  equal(-1, SIMD.Int16x8.extractLane(o, 7));
-});
-
-test('Int16x8 xor', function() {
-  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
-  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  var o = SIMD.Int16x8.xor(m,n);  // xor
-  equal(-1, SIMD.Int16x8.extractLane(o, 0));
-  equal(-1, SIMD.Int16x8.extractLane(o, 1));
-  equal(-1, SIMD.Int16x8.extractLane(o, 2));
-  equal(-1, SIMD.Int16x8.extractLane(o, 3));
-  equal(-1, SIMD.Int16x8.extractLane(o, 4));
-  equal(-1, SIMD.Int16x8.extractLane(o, 5));
-  equal(-1, SIMD.Int16x8.extractLane(o, 6));
-  equal(-1, SIMD.Int16x8.extractLane(o, 7));
-  o = SIMD.Int16x8.xor(m,m);  // xor
-  equal(0x0, SIMD.Int16x8.extractLane(o, 0));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 1));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 2));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 3));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 4));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 5));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 6));
-  equal(0x0, SIMD.Int16x8.extractLane(o, 7));
-});
-
-test('Int16x8 neg', function() {
-  var m = SIMD.Int16x8(16, -32, 64, -128, 256, -512, 1024, -2048);
-  m = SIMD.Int16x8.neg(m);
-  equal(-16, SIMD.Int16x8.extractLane(m, 0));
-  equal(32, SIMD.Int16x8.extractLane(m, 1));
-  equal(-64, SIMD.Int16x8.extractLane(m, 2));
-  equal(128, SIMD.Int16x8.extractLane(m, 3));
-  equal(-256, SIMD.Int16x8.extractLane(m, 4));
-  equal(512, SIMD.Int16x8.extractLane(m, 5));
-  equal(-1024, SIMD.Int16x8.extractLane(m, 6));
-  equal(2048, SIMD.Int16x8.extractLane(m, 7));
-
-  var n = SIMD.Int16x8(0, 0, 0x7fff, 0xffff, -1, -1, 0x8000, 0x0000);
-  n = SIMD.Int16x8.neg(n);
-  equal(0, SIMD.Int16x8.extractLane(n, 0));
-  equal(0, SIMD.Int16x8.extractLane(n, 1));
-  equal(-32767, SIMD.Int16x8.extractLane(n, 2));
-  equal(1, SIMD.Int16x8.extractLane(n, 3));
-  equal(1, SIMD.Int16x8.extractLane(n, 4));
-  equal(1, SIMD.Int16x8.extractLane(n, 5));
-  equal(-32768, SIMD.Int16x8.extractLane(n, 6));
-  equal(0, SIMD.Int16x8.extractLane(n, 7));
-});
-
-test('Int16x8 scalar getters', function () {
-  var a = SIMD.Int16x8(0, 1, -1, -2, 65535, 255, 65536, -500);
-  equal(0, SIMD.Int16x8.extractLane(a, 0));
-  equal(1, SIMD.Int16x8.extractLane(a, 1));
-  equal(-1, SIMD.Int16x8.extractLane(a, 2));
-  equal(-2, SIMD.Int16x8.extractLane(a, 3));
-  equal(-1, SIMD.Int16x8.extractLane(a, 4));
-  equal(255, SIMD.Int16x8.extractLane(a, 5));
-  equal(0, SIMD.Int16x8.extractLane(a, 6));
-  equal(-500, SIMD.Int16x8.extractLane(a, 7));
-
-  equal(0, SIMD.Int16x8.unsignedExtractLane(a, 0));
-  equal(1, SIMD.Int16x8.unsignedExtractLane(a, 1));
-  equal(65535, SIMD.Int16x8.unsignedExtractLane(a, 2));
-  equal(65534, SIMD.Int16x8.unsignedExtractLane(a, 3));
-  equal(65535, SIMD.Int16x8.unsignedExtractLane(a, 4));
-  equal(255, SIMD.Int16x8.unsignedExtractLane(a, 5));
-  equal(0, SIMD.Int16x8.unsignedExtractLane(a, 6));
-  equal(65036, SIMD.Int16x8.unsignedExtractLane(a, 7));
-});
-
-test('Int16x8 add', function() {
-  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x7fff, 0xffff, 0x0, 0x0);
-  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
-  var c = SIMD.Int16x8.add(a, b);
-  equal(-1, SIMD.Int16x8.extractLane(c, 0));
-  equal(0, SIMD.Int16x8.extractLane(c, 1));
-  equal(-2, SIMD.Int16x8.extractLane(c, 2));
-  equal(-2, SIMD.Int16x8.extractLane(c, 3));
-  equal(0x7fff, SIMD.Int16x8.extractLane(c, 4));
-  equal(0, SIMD.Int16x8.extractLane(c, 5));
-  equal(-1, SIMD.Int16x8.extractLane(c, 6));
-  equal(-1, SIMD.Int16x8.extractLane(c, 7));
-});
-
-test('Int16x8 sub', function() {
-  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
-  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0x0FFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
-  var c = SIMD.Int16x8.sub(a, b);
-  equal(-1, SIMD.Int16x8.extractLane(c, 0));
-  equal(-2, SIMD.Int16x8.extractLane(c, 1));
-  equal(0, SIMD.Int16x8.extractLane(c, 2));
-  equal(0, SIMD.Int16x8.extractLane(c, 3));
-  equal(-32768, SIMD.Int16x8.extractLane(c, 4));
-  equal(-1, SIMD.Int16x8.extractLane(c, 5));
-  equal(1, SIMD.Int16x8.extractLane(c, 6));
-  equal(1, SIMD.Int16x8.extractLane(c, 7));
-});
-
-test('Int16x8 mul', function() {
-  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
-  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0xFFFF, 0xFFFF);
-  var c = SIMD.Int16x8.mul(a, b);
-  equal(0, SIMD.Int16x8.extractLane(c, 0));
-  equal(-1, SIMD.Int16x8.extractLane(c, 1));
-  equal(1, SIMD.Int16x8.extractLane(c, 2));
-  equal(1, SIMD.Int16x8.extractLane(c, 3));
-  equal(0, SIMD.Int16x8.extractLane(c, 4));
-  equal(0, SIMD.Int16x8.extractLane(c, 5));
-  equal(0, SIMD.Int16x8.extractLane(c, 6));
-  equal(0, SIMD.Int16x8.extractLane(c, 7));
-});
-
-test('Int16x8 addSaturate', function() {
-  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
-  var b = SIMD.Int16x8.splat(1);
-  var c = SIMD.Int16x8.splat(-1);
-  var d = SIMD.Int16x8.addSaturate(a, b);
-  var e = SIMD.Int16x8.addSaturate(a, c);
-  equal(1, SIMD.Int16x8.extractLane(d, 0));
-  equal(2, SIMD.Int16x8.extractLane(d, 1));
-  equal(0x7fff, SIMD.Int16x8.extractLane(d, 2));
-  equal(-0x7fff, SIMD.Int16x8.extractLane(d, 3));
-  equal(0, SIMD.Int16x8.extractLane(d, 4));
-  equal(0x7fff, SIMD.Int16x8.extractLane(d, 5));
-  equal(-0x7ffe, SIMD.Int16x8.extractLane(d, 6));
-  equal(11, SIMD.Int16x8.extractLane(d, 7));
-  equal(-1, SIMD.Int16x8.extractLane(e, 0));
-  equal(0, SIMD.Int16x8.extractLane(e, 1));
-  equal(0x7ffe, SIMD.Int16x8.extractLane(e, 2));
-  equal(-0x8000, SIMD.Int16x8.extractLane(e, 3));
-  equal(-2, SIMD.Int16x8.extractLane(e, 4));
-  equal(0x7ffd, SIMD.Int16x8.extractLane(e, 5));
-  equal(-0x8000, SIMD.Int16x8.extractLane(e, 6));
-  equal(9, SIMD.Int16x8.extractLane(e, 7));
-});
-
-test('Int16x8 subSaturate', function() {
-  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
-  var b = SIMD.Int16x8.splat(1);
-  var c = SIMD.Int16x8.splat(-1);
-  var d = SIMD.Int16x8.subSaturate(a, b);
-  var e = SIMD.Int16x8.subSaturate(a, c);
-  equal(-1, SIMD.Int16x8.extractLane(d, 0));
-  equal(0, SIMD.Int16x8.extractLane(d, 1));
-  equal(0x7ffe, SIMD.Int16x8.extractLane(d, 2));
-  equal(-0x8000, SIMD.Int16x8.extractLane(d, 3));
-  equal(-2, SIMD.Int16x8.extractLane(d, 4));
-  equal(0x7ffd, SIMD.Int16x8.extractLane(d, 5));
-  equal(-0x8000, SIMD.Int16x8.extractLane(d, 6));
-  equal(9, SIMD.Int16x8.extractLane(d, 7));
-  equal(1, SIMD.Int16x8.extractLane(e, 0));
-  equal(2, SIMD.Int16x8.extractLane(e, 1));
-  equal(0x7fff, SIMD.Int16x8.extractLane(e, 2));
-  equal(-0x7fff, SIMD.Int16x8.extractLane(e, 3));
-  equal(0, SIMD.Int16x8.extractLane(e, 4));
-  equal(0x7fff, SIMD.Int16x8.extractLane(e, 5));
-  equal(-0x7ffe, SIMD.Int16x8.extractLane(e, 6));
-  equal(11, SIMD.Int16x8.extractLane(e, 7));
-});
-
-test('Int16x8 unsignedAbsoluteDifference', function() {
-  var a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
-  var b = SIMD.Int16x8(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1);
-  var c = SIMD.Int16x8.unsignedAbsoluteDifference(a, b);
-  equal(0xff, SIMD.Int16x8.unsignedExtractLane(c, 0));
-  equal(0xff, SIMD.Int16x8.unsignedExtractLane(c, 1));
-  equal(0xfe, SIMD.Int16x8.unsignedExtractLane(c, 2));
-  equal(0xfe, SIMD.Int16x8.unsignedExtractLane(c, 3));
-  equal(1, SIMD.Int16x8.unsignedExtractLane(c, 4));
-  equal(1, SIMD.Int16x8.unsignedExtractLane(c, 5));
-  equal(0xfffc, SIMD.Int16x8.unsignedExtractLane(c, 6));
-  equal(0xfffc, SIMD.Int16x8.unsignedExtractLane(c, 7));
-});
-
-test('Int16x8 widenedUnsignedAbsoluteDifference', function() {
-  var a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
-  var b = SIMD.Int16x8(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1);
-  var c = SIMD.Int16x8.widenedUnsignedAbsoluteDifference(a, b);
-  equal(255, SIMD.Int32x4.extractLane(c, 0));
-  equal(255, SIMD.Int32x4.extractLane(c, 1));
-  equal(254, SIMD.Int32x4.extractLane(c, 2));
-  equal(254, SIMD.Int32x4.extractLane(c, 3));
-});
-
-test('Int16x8 unsignedHorizontalSum', function() {
-  var a = SIMD.Int16x8.splat(0);
-  var b = SIMD.Int16x8.unsignedHorizontalSum(a);
-  equal(0, b);
-
-  var a = SIMD.Int16x8.splat(-1);
-  var b = SIMD.Int16x8.unsignedHorizontalSum(a);
-  equal(524280, b);
-
-  a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
-  b = SIMD.Int16x8.unsignedHorizontalSum(a);
-  equal(66052, b);
-});
-
-test('Int16x8 comparisons', function() {
-  var m = SIMD.Int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
-  var n = SIMD.Int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
-  var cmp;
-  cmp = SIMD.Int16x8.lessThan(m, n);
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Int16x8.lessThanOrEqual(m, n);
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Int16x8.equal(m, n);
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Int16x8.notEqual(m, n);
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Int16x8.greaterThan(m, n);
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
-
-  cmp = SIMD.Int16x8.greaterThanOrEqual(m, n);
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
-  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
-  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
-});
-
-test('Int16x8 shiftLeftByScalar', function() {
-  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int16x8.shiftLeftByScalar(a, 1);
-  equal(SIMD.Int16x8.extractLane(b, 0), -2);
-  equal(SIMD.Int16x8.extractLane(b, 1), -2);
-  equal(SIMD.Int16x8.extractLane(b, 2), -2);
-  equal(SIMD.Int16x8.extractLane(b, 3), -2);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0002);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftLeftByScalar(a, 2);
-  equal(SIMD.Int16x8.extractLane(b, 0), -4);
-  equal(SIMD.Int16x8.extractLane(b, 1), -4);
-  equal(SIMD.Int16x8.extractLane(b, 2), -4);
-  equal(SIMD.Int16x8.extractLane(b, 3), -4);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0004);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftLeftByScalar(a, 14);
-  equal(SIMD.Int16x8.extractLane(b, 0), -16384);
-  equal(SIMD.Int16x8.extractLane(b, 1), -16384);
-  equal(SIMD.Int16x8.extractLane(b, 2), -16384);
-  equal(SIMD.Int16x8.extractLane(b, 3), -16384);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x4000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftLeftByScalar(a, 15);
-  equal(SIMD.Int16x8.extractLane(b, 0), -32768);
-  equal(SIMD.Int16x8.extractLane(b, 1), -32768);
-  equal(SIMD.Int16x8.extractLane(b, 2), -32768);
-  equal(SIMD.Int16x8.extractLane(b, 3), -32768);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), -32768);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftLeftByScalar(a, 16);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.Int16x8.shiftLeftByScalar(a, -1);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-});
-
-test('Int16x8 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x3fff);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x1fff);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 14);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0001);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 15);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 16);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.Int16x8.extractLane(b, 0), -1);
-  equal(SIMD.Int16x8.extractLane(b, 1), -1);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), -1);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-});
-
-test('Int16x8 shiftRightLogicalByScalar', function() {
-  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x7fff);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x7fff);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x3fff);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x7fff);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x3fff);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x3fff);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x1fff);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x3fff);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 14);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0003);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0003);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0001);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0003);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 15);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0001);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0001);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0001);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 16);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
-});
-
-test('Int16x8 select', function() {
-  var m = SIMD.Bool16x8(true, true, true, true, false, false, false, false);
-  var t = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var f = SIMD.Int16x8(9, 10, 11, 12, 13, 14, 15, 16);
-  var s = SIMD.Int16x8.select(m, t, f);
-  equal(1, SIMD.Int16x8.extractLane(s, 0));
-  equal(2, SIMD.Int16x8.extractLane(s, 1));
-  equal(3, SIMD.Int16x8.extractLane(s, 2));
-  equal(4, SIMD.Int16x8.extractLane(s, 3));
-  equal(13, SIMD.Int16x8.extractLane(s, 4));
-  equal(14, SIMD.Int16x8.extractLane(s, 5));
-  equal(15, SIMD.Int16x8.extractLane(s, 6));
-  equal(16, SIMD.Int16x8.extractLane(s, 7));
-});
-
-test('Int8x16 swizzle', function() {
-  var a    = SIMD.Int8x16(1, 2, 3, 2147483647, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -37);
-  var xyxy = SIMD.Int8x16.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
-  var zwzw = SIMD.Int8x16.swizzle(a, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9);
-  var xxxx = SIMD.Int8x16.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 0));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 1));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 2));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 3));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 4));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 5));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 6));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 7));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 8));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 9));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 10));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 11));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 12));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 13));
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 14));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 15));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 0));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 1));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 2));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 3));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 4));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 5));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 6));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 7));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 8));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 9));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 10));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 11));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 12));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 13));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 14));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 15));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 0));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 1));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 2));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 3));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 4));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 5));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 6));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 7));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 8));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 9));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 10));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 11));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 12));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 13));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 14));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 15));
-
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int8x16.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(16);
-});
-
-test('Int8x16 shuffle', function() {
-  var a    = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var b    = SIMD.Int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127);
-  var xyxy = SIMD.Int8x16.shuffle(a, b, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
-  var zwzw = SIMD.Int8x16.shuffle(a, b, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
-  var xxxx = SIMD.Int8x16.shuffle(a, b, 0, 0, 0, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16, 16, 16);
-  equal(1, SIMD.Int8x16.extractLane(xyxy, 0));
-  equal(2, SIMD.Int8x16.extractLane(xyxy, 1));
-  equal(3, SIMD.Int8x16.extractLane(xyxy, 2));
-  equal(4, SIMD.Int8x16.extractLane(xyxy, 3));
-  equal(5, SIMD.Int8x16.extractLane(xyxy, 4));
-  equal(6, SIMD.Int8x16.extractLane(xyxy, 5));
-  equal(7, SIMD.Int8x16.extractLane(xyxy, 6));
-  equal(8, SIMD.Int8x16.extractLane(xyxy, 7));
-  equal(17, SIMD.Int8x16.extractLane(xyxy, 8));
-  equal(18, SIMD.Int8x16.extractLane(xyxy, 9));
-  equal(19, SIMD.Int8x16.extractLane(xyxy, 10));
-  equal(20, SIMD.Int8x16.extractLane(xyxy, 11));
-  equal(21, SIMD.Int8x16.extractLane(xyxy, 12));
-  equal(22, SIMD.Int8x16.extractLane(xyxy, 13));
-  equal(23, SIMD.Int8x16.extractLane(xyxy, 14));
-  equal(24, SIMD.Int8x16.extractLane(xyxy, 15));
-  equal(9, SIMD.Int8x16.extractLane(zwzw, 0));
-  equal(10, SIMD.Int8x16.extractLane(zwzw, 1));
-  equal(11, SIMD.Int8x16.extractLane(zwzw, 2));
-  equal(12, SIMD.Int8x16.extractLane(zwzw, 3));
-  equal(13, SIMD.Int8x16.extractLane(zwzw, 4));
-  equal(14, SIMD.Int8x16.extractLane(zwzw, 5));
-  equal(15, SIMD.Int8x16.extractLane(zwzw, 6));
-  equal(16, SIMD.Int8x16.extractLane(zwzw, 7));
-  equal(25, SIMD.Int8x16.extractLane(zwzw, 8));
-  equal(26, SIMD.Int8x16.extractLane(zwzw, 9));
-  equal(27, SIMD.Int8x16.extractLane(zwzw, 10));
-  equal(28, SIMD.Int8x16.extractLane(zwzw, 11));
-  equal(29, SIMD.Int8x16.extractLane(zwzw, 12));
-  equal(30, SIMD.Int8x16.extractLane(zwzw, 13));
-  equal(31, SIMD.Int8x16.extractLane(zwzw, 14));
-  equal(127, SIMD.Int8x16.extractLane(zwzw, 15));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 0));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 1));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 2));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 3));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 4));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 5));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 6));
-  equal(1, SIMD.Int8x16.extractLane(xxxx, 7));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 8));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 9));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 10));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 11));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 12));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 13));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 14));
-  equal(17, SIMD.Int8x16.extractLane(xxxx, 15));
-
-  function testIndexCheck(index) {
-      throws(function() { SIMD.Int8x16.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
-  }
-  testIndexCheck(13.37);
-  testIndexCheck(null);
-  testIndexCheck(undefined);
-  testIndexCheck({});
-  testIndexCheck(true);
-  testIndexCheck('yo');
-  testIndexCheck(-1);
-  testIndexCheck(32);
-});
-
-test('Int8x16 and', function() {
-  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 170, 170, 170, 170, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  equal(-86, SIMD.Int8x16.extractLane(m, 0));
-  equal(-86, SIMD.Int8x16.extractLane(m, 1));
-  equal(-86, SIMD.Int8x16.extractLane(m, 2));
-  equal(-86, SIMD.Int8x16.extractLane(m, 3));
-  equal(-86, SIMD.Int8x16.extractLane(m, 4));
-  equal(-86, SIMD.Int8x16.extractLane(m, 5));
-  equal(-86, SIMD.Int8x16.extractLane(m, 6));
-  equal(-86, SIMD.Int8x16.extractLane(m, 7));
-  equal(-86, SIMD.Int8x16.extractLane(m, 8));
-  equal(-86, SIMD.Int8x16.extractLane(m, 9));
-  equal(-86, SIMD.Int8x16.extractLane(m, 10));
-  equal(-86, SIMD.Int8x16.extractLane(m, 11));
-  equal(-86, SIMD.Int8x16.extractLane(m, 12));
-  equal(-86, SIMD.Int8x16.extractLane(m, 13));
-  equal(-86, SIMD.Int8x16.extractLane(m, 14));
-  equal(-86, SIMD.Int8x16.extractLane(m, 15));
-  equal(85, SIMD.Int8x16.extractLane(n, 0));
-  equal(85, SIMD.Int8x16.extractLane(n, 1));
-  equal(85, SIMD.Int8x16.extractLane(n, 2));
-  equal(85, SIMD.Int8x16.extractLane(n, 3));
-  equal(85, SIMD.Int8x16.extractLane(n, 4));
-  equal(85, SIMD.Int8x16.extractLane(n, 5));
-  equal(85, SIMD.Int8x16.extractLane(n, 6));
-  equal(85, SIMD.Int8x16.extractLane(n, 7));
-  equal(85, SIMD.Int8x16.extractLane(n, 8));
-  equal(85, SIMD.Int8x16.extractLane(n, 9));
-  equal(85, SIMD.Int8x16.extractLane(n, 10));
-  equal(85, SIMD.Int8x16.extractLane(n, 11));
-  equal(85, SIMD.Int8x16.extractLane(n, 12));
-  equal(85, SIMD.Int8x16.extractLane(n, 13));
-  equal(85, SIMD.Int8x16.extractLane(n, 14));
-  equal(85, SIMD.Int8x16.extractLane(n, 15));
-  var o = SIMD.Int8x16.and(m,n);  // and
-  equal(0x0, SIMD.Int8x16.extractLane(o, 0));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 1));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 2));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 3));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 4));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 5));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 6));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 7));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 8));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 9));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 10));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 11));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 12));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 13));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 14));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 15));
-});
-
-test('Int8x16 or', function() {
-  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  var o = SIMD.Int8x16.or(m,n);  // or
-  equal(-1, SIMD.Int8x16.extractLane(o, 0));
-  equal(-1, SIMD.Int8x16.extractLane(o, 1));
-  equal(-1, SIMD.Int8x16.extractLane(o, 2));
-  equal(-1, SIMD.Int8x16.extractLane(o, 3));
-  equal(-1, SIMD.Int8x16.extractLane(o, 4));
-  equal(-1, SIMD.Int8x16.extractLane(o, 5));
-  equal(-1, SIMD.Int8x16.extractLane(o, 6));
-  equal(-1, SIMD.Int8x16.extractLane(o, 7));
-  equal(-1, SIMD.Int8x16.extractLane(o, 8));
-  equal(-1, SIMD.Int8x16.extractLane(o, 9));
-  equal(-1, SIMD.Int8x16.extractLane(o, 10));
-  equal(-1, SIMD.Int8x16.extractLane(o, 11));
-  equal(-1, SIMD.Int8x16.extractLane(o, 12));
-  equal(-1, SIMD.Int8x16.extractLane(o, 13));
-  equal(-1, SIMD.Int8x16.extractLane(o, 14));
-  equal(-1, SIMD.Int8x16.extractLane(o, 15));
-});
-
-test('Int8x16 xor', function() {
-  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  var o = SIMD.Int8x16.xor(m,n);  // xor
-  equal(-1, SIMD.Int8x16.extractLane(o, 0));
-  equal(-1, SIMD.Int8x16.extractLane(o, 1));
-  equal(-1, SIMD.Int8x16.extractLane(o, 2));
-  equal(-1, SIMD.Int8x16.extractLane(o, 3));
-  equal(-1, SIMD.Int8x16.extractLane(o, 4));
-  equal(-1, SIMD.Int8x16.extractLane(o, 5));
-  equal(-1, SIMD.Int8x16.extractLane(o, 6));
-  equal(-1, SIMD.Int8x16.extractLane(o, 7));
-  equal(-1, SIMD.Int8x16.extractLane(o, 8));
-  equal(-1, SIMD.Int8x16.extractLane(o, 9));
-  equal(-1, SIMD.Int8x16.extractLane(o, 10));
-  equal(-1, SIMD.Int8x16.extractLane(o, 11));
-  equal(-1, SIMD.Int8x16.extractLane(o, 12));
-  equal(-1, SIMD.Int8x16.extractLane(o, 13));
-  equal(-1, SIMD.Int8x16.extractLane(o, 14));
-  equal(-1, SIMD.Int8x16.extractLane(o, 15));
-  o = SIMD.Int8x16.xor(m,m);  // xor
-  equal(0x0, SIMD.Int8x16.extractLane(o, 0));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 1));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 2));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 3));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 4));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 5));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 6));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 7));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 8));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 9));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 10));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 11));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 12));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 13));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 14));
-  equal(0x0, SIMD.Int8x16.extractLane(o, 15));
-});
-
-test('Int8x16 neg', function() {
-  var m = SIMD.Int8x16(16, -32, 64, -128, 256, -512, 1024, -2048, 4096, -8192, 16384, -32768, 65536, -131072, 262144, -524288);
-  m = SIMD.Int8x16.neg(m);
-  equal(-16, SIMD.Int8x16.extractLane(m, 0));
-  equal(32, SIMD.Int8x16.extractLane(m, 1));
-  equal(-64, SIMD.Int8x16.extractLane(m, 2));
-  equal(-128, SIMD.Int8x16.extractLane(m, 3));
-  equal(0, SIMD.Int8x16.extractLane(m, 4));
-  equal(0, SIMD.Int8x16.extractLane(m, 5));
-  equal(0, SIMD.Int8x16.extractLane(m, 6));
-  equal(0, SIMD.Int8x16.extractLane(m, 7));
-  equal(0, SIMD.Int8x16.extractLane(m, 8));
-  equal(0, SIMD.Int8x16.extractLane(m, 9));
-  equal(0, SIMD.Int8x16.extractLane(m, 10));
-  equal(0, SIMD.Int8x16.extractLane(m, 11));
-  equal(0, SIMD.Int8x16.extractLane(m, 12));
-  equal(0, SIMD.Int8x16.extractLane(m, 13));
-  equal(0, SIMD.Int8x16.extractLane(m, 14));
-  equal(0, SIMD.Int8x16.extractLane(m, 15));
-
-  var n = SIMD.Int8x16(0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff, -1, -1, -1, -1, 0x80, 0x00, 0x00, 0x00);
-  n = SIMD.Int8x16.neg(n);
-  equal(0, SIMD.Int8x16.extractLane(n, 0));
-  equal(0, SIMD.Int8x16.extractLane(n, 1));
-  equal(0, SIMD.Int8x16.extractLane(n, 2));
-  equal(0, SIMD.Int8x16.extractLane(n, 3));
-  equal(-127, SIMD.Int8x16.extractLane(n, 4));
-  equal(1, SIMD.Int8x16.extractLane(n, 5));
-  equal(1, SIMD.Int8x16.extractLane(n, 6));
-  equal(1, SIMD.Int8x16.extractLane(n, 7));
-  equal(1, SIMD.Int8x16.extractLane(n, 8));
-  equal(1, SIMD.Int8x16.extractLane(n, 9));
-  equal(1, SIMD.Int8x16.extractLane(n, 10));
-  equal(1, SIMD.Int8x16.extractLane(n, 11));
-  equal(-128, SIMD.Int8x16.extractLane(n, 12));
-  equal(0, SIMD.Int8x16.extractLane(n, 13));
-  equal(0, SIMD.Int8x16.extractLane(n, 14));
-  equal(0, SIMD.Int8x16.extractLane(n, 15));
-});
-
-test('Int8x16 scalar getters', function () {
-  var a = SIMD.Int8x16(0, 1, -1, -2, 65535, 255, 65536, -500,
-                       2, -3, 4, -5, 6, -7, 8, -9);
-  equal(0, SIMD.Int8x16.extractLane(a, 0));
-  equal(1, SIMD.Int8x16.extractLane(a, 1));
-  equal(-1, SIMD.Int8x16.extractLane(a, 2));
-  equal(-2, SIMD.Int8x16.extractLane(a, 3));
-  equal(-1, SIMD.Int8x16.extractLane(a, 4));
-  equal(-1, SIMD.Int8x16.extractLane(a, 5));
-  equal(0, SIMD.Int8x16.extractLane(a, 6));
-  equal(12, SIMD.Int8x16.extractLane(a, 7));
-  equal(2, SIMD.Int8x16.extractLane(a, 8));
-  equal(-3, SIMD.Int8x16.extractLane(a, 9));
-  equal(4, SIMD.Int8x16.extractLane(a, 10));
-  equal(-5, SIMD.Int8x16.extractLane(a, 11));
-  equal(6, SIMD.Int8x16.extractLane(a, 12));
-  equal(-7, SIMD.Int8x16.extractLane(a, 13));
-  equal(8, SIMD.Int8x16.extractLane(a, 14));
-  equal(-9, SIMD.Int8x16.extractLane(a, 15));
-
-  equal(0, SIMD.Int8x16.unsignedExtractLane(a, 0));
-  equal(1, SIMD.Int8x16.unsignedExtractLane(a, 1));
-  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 2));
-  equal(254, SIMD.Int8x16.unsignedExtractLane(a, 3));
-  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 4));
-  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 5));
-  equal(0, SIMD.Int8x16.unsignedExtractLane(a, 6));
-  equal(12, SIMD.Int8x16.unsignedExtractLane(a, 7));
-  equal(2, SIMD.Int8x16.unsignedExtractLane(a, 8));
-  equal(253, SIMD.Int8x16.unsignedExtractLane(a, 9));
-  equal(4, SIMD.Int8x16.unsignedExtractLane(a, 10));
-  equal(251, SIMD.Int8x16.unsignedExtractLane(a, 11));
-  equal(6, SIMD.Int8x16.unsignedExtractLane(a, 12));
-  equal(249, SIMD.Int8x16.unsignedExtractLane(a, 13));
-  equal(8, SIMD.Int8x16.unsignedExtractLane(a, 14));
-  equal(247, SIMD.Int8x16.unsignedExtractLane(a, 15));
-});
-
-test('Int8x16 add', function () {
-  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.Int8x16.add(a, b);
-  equal(-1, SIMD.Int8x16.extractLane(c, 0));
-  equal(-1, SIMD.Int8x16.extractLane(c, 1));
-  equal(-1, SIMD.Int8x16.extractLane(c, 2));
-  equal(0x0, SIMD.Int8x16.extractLane(c, 3));
-  equal(-2, SIMD.Int8x16.extractLane(c, 4));
-  equal(-2, SIMD.Int8x16.extractLane(c, 5));
-  equal(-2, SIMD.Int8x16.extractLane(c, 6));
-  equal(-2, SIMD.Int8x16.extractLane(c, 7));
-  equal(0x7f, SIMD.Int8x16.extractLane(c, 8));
-  equal(-1, SIMD.Int8x16.extractLane(c, 9));
-  equal(-1, SIMD.Int8x16.extractLane(c, 10));
-  equal(0x0, SIMD.Int8x16.extractLane(c, 11));
-  equal(-1, SIMD.Int8x16.extractLane(c, 12));
-  equal(-1, SIMD.Int8x16.extractLane(c, 13));
-  equal(-1, SIMD.Int8x16.extractLane(c, 14));
-  equal(-1, SIMD.Int8x16.extractLane(c, 15));
-});
-
-test('Int8x16 sub', function() {
-  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.Int8x16.sub(a, b);
-  equal(-1, SIMD.Int8x16.extractLane(c, 0));
-  equal(-1, SIMD.Int8x16.extractLane(c, 1));
-  equal(-1, SIMD.Int8x16.extractLane(c, 2));
-  equal(-2, SIMD.Int8x16.extractLane(c, 3));
-  equal(0, SIMD.Int8x16.extractLane(c, 4));
-  equal(0, SIMD.Int8x16.extractLane(c, 5));
-  equal(0, SIMD.Int8x16.extractLane(c, 6));
-  equal(0, SIMD.Int8x16.extractLane(c, 7));
-  equal(0x7f, SIMD.Int8x16.extractLane(c, 8));
-  equal(-1, SIMD.Int8x16.extractLane(c, 9));
-  equal(-1, SIMD.Int8x16.extractLane(c, 10));
-  equal(-2, SIMD.Int8x16.extractLane(c, 11));
-  equal(1, SIMD.Int8x16.extractLane(c, 12));
-  equal(1, SIMD.Int8x16.extractLane(c, 13));
-  equal(1, SIMD.Int8x16.extractLane(c, 14));
-  equal(1, SIMD.Int8x16.extractLane(c, 15));
-});
-
-test('Int8x16 mul', function() {
-  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.Int8x16.mul(a, b);
-  equal(0x0, SIMD.Int8x16.extractLane(c, 0));
-  equal(0x0, SIMD.Int8x16.extractLane(c, 1));
-  equal(0x0, SIMD.Int8x16.extractLane(c, 2));
-  equal(-1, SIMD.Int8x16.extractLane(c, 3));
-  equal(1, SIMD.Int8x16.extractLane(c, 4));
-  equal(1, SIMD.Int8x16.extractLane(c, 5));
-  equal(1, SIMD.Int8x16.extractLane(c, 6));
-  equal(1, SIMD.Int8x16.extractLane(c, 7));
-  equal(0, SIMD.Int8x16.extractLane(c, 8));
-  equal(0, SIMD.Int8x16.extractLane(c, 9));
-  equal(0, SIMD.Int8x16.extractLane(c, 10));
-  equal(-1, SIMD.Int8x16.extractLane(c, 11));
-  equal(0, SIMD.Int8x16.extractLane(c, 12));
-  equal(0, SIMD.Int8x16.extractLane(c, 13));
-  equal(0, SIMD.Int8x16.extractLane(c, 14));
-  equal(0, SIMD.Int8x16.extractLane(c, 15));
-});
-
-test('Int8x16 addSaturate', function() {
-  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
-  var b = SIMD.Int8x16.splat(1);
-  var c = SIMD.Int8x16.splat(-1);
-  var d = SIMD.Int8x16.addSaturate(a, b);
-  var e = SIMD.Int8x16.addSaturate(a, c);
-  equal(1, SIMD.Int8x16.extractLane(d, 0));
-  equal(2, SIMD.Int8x16.extractLane(d, 1));
-  equal(0x7f, SIMD.Int8x16.extractLane(d, 2));
-  equal(-0x7f, SIMD.Int8x16.extractLane(d, 3));
-  equal(0, SIMD.Int8x16.extractLane(d, 4));
-  equal(0x7f, SIMD.Int8x16.extractLane(d, 5));
-  equal(-0x7e, SIMD.Int8x16.extractLane(d, 6));
-  equal(11, SIMD.Int8x16.extractLane(d, 7));
-  equal(12, SIMD.Int8x16.extractLane(d, 8));
-  equal(13, SIMD.Int8x16.extractLane(d, 9));
-  equal(14, SIMD.Int8x16.extractLane(d, 10));
-  equal(15, SIMD.Int8x16.extractLane(d, 11));
-  equal(16, SIMD.Int8x16.extractLane(d, 12));
-  equal(17, SIMD.Int8x16.extractLane(d, 13));
-  equal(18, SIMD.Int8x16.extractLane(d, 14));
-  equal(19, SIMD.Int8x16.extractLane(d, 15));
-  equal(-1, SIMD.Int8x16.extractLane(e, 0));
-  equal(0, SIMD.Int8x16.extractLane(e, 1));
-  equal(0x7e, SIMD.Int8x16.extractLane(e, 2));
-  equal(-0x80, SIMD.Int8x16.extractLane(e, 3));
-  equal(-2, SIMD.Int8x16.extractLane(e, 4));
-  equal(0x7d, SIMD.Int8x16.extractLane(e, 5));
-  equal(-0x80, SIMD.Int8x16.extractLane(e, 6));
-  equal(9, SIMD.Int8x16.extractLane(e, 7));
-  equal(10, SIMD.Int8x16.extractLane(e, 8));
-  equal(11, SIMD.Int8x16.extractLane(e, 9));
-  equal(12, SIMD.Int8x16.extractLane(e, 10));
-  equal(13, SIMD.Int8x16.extractLane(e, 11));
-  equal(14, SIMD.Int8x16.extractLane(e, 12));
-  equal(15, SIMD.Int8x16.extractLane(e, 13));
-  equal(16, SIMD.Int8x16.extractLane(e, 14));
-  equal(17, SIMD.Int8x16.extractLane(e, 15));
-});
-
-test('Int8x16 subSaturate', function() {
-  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
-  var b = SIMD.Int8x16.splat(1);
-  var c = SIMD.Int8x16.splat(-1);
-  var d = SIMD.Int8x16.subSaturate(a, b);
-  var e = SIMD.Int8x16.subSaturate(a, c);
-  equal(-1, SIMD.Int8x16.extractLane(d, 0));
-  equal(0, SIMD.Int8x16.extractLane(d, 1));
-  equal(0x7e, SIMD.Int8x16.extractLane(d, 2));
-  equal(-0x80, SIMD.Int8x16.extractLane(d, 3));
-  equal(-2, SIMD.Int8x16.extractLane(d, 4));
-  equal(0x7d, SIMD.Int8x16.extractLane(d, 5));
-  equal(-0x80, SIMD.Int8x16.extractLane(d, 6));
-  equal(9, SIMD.Int8x16.extractLane(d, 7));
-  equal(10, SIMD.Int8x16.extractLane(d, 8));
-  equal(11, SIMD.Int8x16.extractLane(d, 9));
-  equal(12, SIMD.Int8x16.extractLane(d, 10));
-  equal(13, SIMD.Int8x16.extractLane(d, 11));
-  equal(14, SIMD.Int8x16.extractLane(d, 12));
-  equal(15, SIMD.Int8x16.extractLane(d, 13));
-  equal(16, SIMD.Int8x16.extractLane(d, 14));
-  equal(17, SIMD.Int8x16.extractLane(d, 15));
-  equal(1, SIMD.Int8x16.extractLane(e, 0));
-  equal(2, SIMD.Int8x16.extractLane(e, 1));
-  equal(0x7f, SIMD.Int8x16.extractLane(e, 2));
-  equal(-0x7f, SIMD.Int8x16.extractLane(e, 3));
-  equal(0, SIMD.Int8x16.extractLane(e, 4));
-  equal(0x7f, SIMD.Int8x16.extractLane(e, 5));
-  equal(-0x7e, SIMD.Int8x16.extractLane(e, 6));
-  equal(11, SIMD.Int8x16.extractLane(e, 7));
-  equal(12, SIMD.Int8x16.extractLane(e, 8));
-  equal(13, SIMD.Int8x16.extractLane(e, 9));
-  equal(14, SIMD.Int8x16.extractLane(e, 10));
-  equal(15, SIMD.Int8x16.extractLane(e, 11));
-  equal(16, SIMD.Int8x16.extractLane(e, 12));
-  equal(17, SIMD.Int8x16.extractLane(e, 13));
-  equal(18, SIMD.Int8x16.extractLane(e, 14));
-  equal(19, SIMD.Int8x16.extractLane(e, 15));
-});
-
-test('Int8x16 unsignedAbsoluteDifference', function() {
-  var a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
-  var b = SIMD.Int8x16(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1, 0, 0x7f, 0xe0, 0xf0, 9, 10, 9, -10);
-  var c = SIMD.Int8x16.unsignedAbsoluteDifference(a, b);
-  equal(255, SIMD.Int8x16.unsignedExtractLane(c, 0));
-  equal(255, SIMD.Int8x16.unsignedExtractLane(c, 1));
-  equal(254, SIMD.Int8x16.unsignedExtractLane(c, 2));
-  equal(254, SIMD.Int8x16.unsignedExtractLane(c, 3));
-  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 4));
-  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 5));
-  equal(252, SIMD.Int8x16.unsignedExtractLane(c, 6));
-  equal(252, SIMD.Int8x16.unsignedExtractLane(c, 7));
-  equal(127, SIMD.Int8x16.unsignedExtractLane(c, 8));
-  equal(127, SIMD.Int8x16.unsignedExtractLane(c, 9));
-  equal(16, SIMD.Int8x16.unsignedExtractLane(c, 10));
-  equal(16, SIMD.Int8x16.unsignedExtractLane(c, 11));
-  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 12));
-  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 13));
-  equal(237, SIMD.Int8x16.unsignedExtractLane(c, 14));
-  equal(237, SIMD.Int8x16.unsignedExtractLane(c, 15));
-});
-
-test('Int8x16 widenedUnsignedAbsoluteDifference', function() {
-  var a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
-  var b = SIMD.Int8x16(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1, 0, 0x7f, 0xe0, 0xf0, 9, 10, 9, -10);
-  var c = SIMD.Int8x16.widenedUnsignedAbsoluteDifference(a, b);
-  equal(255, SIMD.Int16x8.extractLane(c, 0));
-  equal(255, SIMD.Int16x8.extractLane(c, 1));
-  equal(254, SIMD.Int16x8.extractLane(c, 2));
-  equal(254, SIMD.Int16x8.extractLane(c, 3));
-  equal(1, SIMD.Int16x8.extractLane(c, 4));
-  equal(1, SIMD.Int16x8.extractLane(c, 5));
-  equal(252, SIMD.Int16x8.extractLane(c, 6));
-  equal(252, SIMD.Int16x8.extractLane(c, 7));
-});
-
-test('Int8x16 unsignedHorizontalSum', function() {
-  var a = SIMD.Int8x16.splat(0);
-  var b = SIMD.Int8x16.unsignedHorizontalSum(a);
-  equal(0, b);
-
-  var a = SIMD.Int8x16.splat(-1);
-  var b = SIMD.Int8x16.unsignedHorizontalSum(a);
-  equal(4080, b);
-
-  a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
-  b = SIMD.Int8x16.unsignedHorizontalSum(a);
-  equal(1637, b);
-});
-
-test('Int8x16 comparisons', function() {
-  var m = SIMD.Int8x16(1000, 2000, 100, 1, -1000, -2000, -100, 1, 0, 0, 0, 0, -1, 1, -2, 2);
-  var n = SIMD.Int8x16(-2000, 2000, 1, 100, 2000, -2000, -1, -100, -1, 1, -2, 2, 0, 0, 0, 0);
-  var cmp;
-  cmp = SIMD.Int8x16.lessThan(m, n);
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Int8x16.lessThanOrEqual(m, n);
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Int8x16.equal(m, n);
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Int8x16.notEqual(m, n);
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Int8x16.greaterThan(m, n);
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
-
-  cmp = SIMD.Int8x16.greaterThanOrEqual(m, n);
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
-  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
-  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
-});
-
-test('Int8x16 shiftLeftByScalar', function() {
-  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int8x16.shiftLeftByScalar(a, 1);
-  equal(SIMD.Int8x16.extractLane(b, 0), -2);
-  equal(SIMD.Int8x16.extractLane(b, 1), -2);
-  equal(SIMD.Int8x16.extractLane(b, 2), -2);
-  equal(SIMD.Int8x16.extractLane(b, 3), -2);
-  equal(SIMD.Int8x16.extractLane(b, 4), -2);
-  equal(SIMD.Int8x16.extractLane(b, 5), -2);
-  equal(SIMD.Int8x16.extractLane(b, 6), -2);
-  equal(SIMD.Int8x16.extractLane(b, 7), -2);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x02);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftLeftByScalar(a, 2);
-  equal(SIMD.Int8x16.extractLane(b, 0), -4);
-  equal(SIMD.Int8x16.extractLane(b, 1), -4);
-  equal(SIMD.Int8x16.extractLane(b, 2), -4);
-  equal(SIMD.Int8x16.extractLane(b, 3), -4);
-  equal(SIMD.Int8x16.extractLane(b, 4), -4);
-  equal(SIMD.Int8x16.extractLane(b, 5), -4);
-  equal(SIMD.Int8x16.extractLane(b, 6), -4);
-  equal(SIMD.Int8x16.extractLane(b, 7), -4);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x04);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftLeftByScalar(a, 6);
-  equal(SIMD.Int8x16.extractLane(b, 0), -64);
-  equal(SIMD.Int8x16.extractLane(b, 1), -64);
-  equal(SIMD.Int8x16.extractLane(b, 2), -64);
-  equal(SIMD.Int8x16.extractLane(b, 3), -64);
-  equal(SIMD.Int8x16.extractLane(b, 4), -64);
-  equal(SIMD.Int8x16.extractLane(b, 5), -64);
-  equal(SIMD.Int8x16.extractLane(b, 6), -64);
-  equal(SIMD.Int8x16.extractLane(b, 7), -64);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x40);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftLeftByScalar(a, 7);
-  equal(SIMD.Int8x16.extractLane(b, 0), -128);
-  equal(SIMD.Int8x16.extractLane(b, 1), -128);
-  equal(SIMD.Int8x16.extractLane(b, 2), -128);
-  equal(SIMD.Int8x16.extractLane(b, 3), -128);
-  equal(SIMD.Int8x16.extractLane(b, 4), -128);
-  equal(SIMD.Int8x16.extractLane(b, 5), -128);
-  equal(SIMD.Int8x16.extractLane(b, 6), -128);
-  equal(SIMD.Int8x16.extractLane(b, 7), -128);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), -128);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftLeftByScalar(a, 16);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.Int8x16.shiftLeftByScalar(a, -1);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-});
-
-test('Int8x16 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x1f);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 6);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 7);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 8);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.Int8x16.extractLane(b, 0), -1);
-  equal(SIMD.Int8x16.extractLane(b, 1), -1);
-  equal(SIMD.Int8x16.extractLane(b, 2), -1);
-  equal(SIMD.Int8x16.extractLane(b, 3), -1);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), -1);
-  equal(SIMD.Int8x16.extractLane(b, 6), -1);
-  equal(SIMD.Int8x16.extractLane(b, 7), -1);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-});
-
-test('Int8x16 shiftRightLogicalByScalar', function() {
-  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
-  var b;
-
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x7f);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x1f);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x3f);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 6);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x03);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 7);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x01);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 8);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
-});
-
-test('Int8x16 select', function() {
-  var m = SIMD.Bool8x16(true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false);
-  var t = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var f = SIMD.Int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-  var s = SIMD.Int8x16.select(m, t, f);
-  equal(1, SIMD.Int8x16.extractLane(s, 0));
-  equal(2, SIMD.Int8x16.extractLane(s, 1));
-  equal(3, SIMD.Int8x16.extractLane(s, 2));
-  equal(4, SIMD.Int8x16.extractLane(s, 3));
-  equal(5, SIMD.Int8x16.extractLane(s, 4));
-  equal(6, SIMD.Int8x16.extractLane(s, 5));
-  equal(7, SIMD.Int8x16.extractLane(s, 6));
-  equal(8, SIMD.Int8x16.extractLane(s, 7));
-  equal(25, SIMD.Int8x16.extractLane(s, 8));
-  equal(26, SIMD.Int8x16.extractLane(s, 9));
-  equal(27, SIMD.Int8x16.extractLane(s, 10));
-  equal(28, SIMD.Int8x16.extractLane(s, 11));
-  equal(29, SIMD.Int8x16.extractLane(s, 12));
-  equal(30, SIMD.Int8x16.extractLane(s, 13));
-  equal(31, SIMD.Int8x16.extractLane(s, 14));
-  equal(32, SIMD.Int8x16.extractLane(s, 15));
-});
-
-test('Int8x16 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.Int8x16.fromFloat32x4Bits(m);
-  equal(0x00, SIMD.Int8x16.extractLane(n, 0));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 1));
-  equal(-128, SIMD.Int8x16.extractLane(n, 2));
-  equal(0x3f, SIMD.Int8x16.extractLane(n, 3));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 4));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 5));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 6));
-  equal(0x40, SIMD.Int8x16.extractLane(n, 7));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 8));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 9));
-  equal(0x40, SIMD.Int8x16.extractLane(n, 10));
-  equal(0x40, SIMD.Int8x16.extractLane(n, 11));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 12));
-  equal(0x00, SIMD.Int8x16.extractLane(n, 13));
-  equal(-128, SIMD.Int8x16.extractLane(n, 14));
-  equal(0x40, SIMD.Int8x16.extractLane(n, 15));
-});

--- a/src/shell_test_runner.js
+++ b/src/shell_test_runner.js
@@ -18,7 +18,6 @@ function fail(str) {
 }
 
 function test(name, func) {
-  print(name)
   currentName = name;
   if (skipValueTests && name.indexOf("value semantics") != -1) return;
   try {

--- a/src/shell_test_runner.js
+++ b/src/shell_test_runner.js
@@ -18,6 +18,7 @@ function fail(str) {
 }
 
 function test(name, func) {
+  print(name)
   currentName = name;
   if (skipValueTests && name.indexOf("value semantics") != -1) return;
   try {


### PR DESCRIPTION
Rewrites the tests in more parametric style, with some type info to guide things.
Eliminates tests for unsigned* functions that have gone away. We'll add them when we add the unsigned types.
Removes erroneous loadN / storeN from small int types.