### PR TITLE
Don't print non-existent stack trace.

### DIFF
--- a/src/shell_test_runner.js
+++ b/src/shell_test_runner.js
@@ -24,7 +24,8 @@ function test(name, func) {
     func();
   } catch (e) {
     console.log('exception thrown from ' + currentName + ': ' + e.toString());
-    printIndented(e.stack);
+    if (e.stack)
+      printIndented(e.stack);
     numFails++;
   }
 }


### PR DESCRIPTION
e.stack isn't always defined.