### PR TITLE
Fix some bugs in the tests.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -255,7 +255,7 @@ function simdBinaryOp(type, op, a, b) {
 function simdWideningBinaryOp(type, op, a, b) {
   a = type.fn.check(a);
   b = type.fn.check(b);
-  for (var i = 0; i < type.lanes; i++)
+  for (var i = 0; i < type.wideType.lanes; i++)
     lanes[i] = op(type.fn.extractLane(a, i),
                   type.fn.extractLane(b, i));
   return simdCreate(type.wideType);
@@ -738,9 +738,7 @@ uint32x4.fromBits = [float32x4, int32x4, int16x8, int8x16, uint16x8, uint8x16];
 uint16x8.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint8x16];
 uint8x16.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint16x8];
 
-// SIMD widend types.
-int16x8.wideType = int32x4;
-int8x16.wideType = int16x8;
+// SIMD widening types.
 uint16x8.wideType = uint32x4;
 uint8x16.wideType = uint16x8;
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -218,7 +218,10 @@ uint8x16.wideType = uint16x8;
 
 var floatTypes = [float32x4];
 
-var intTypes = [int32x4, int16x8, int8x16];
+var intTypes = [int32x4, int16x8, int8x16,
+                uint32x4, uint16x8, uint8x16];
+
+var signedIntTypes = [int32x4, int16x8, int8x16];
 
 var unsignedIntTypes = [uint32x4, uint16x8, uint8x16];
 
@@ -846,6 +849,9 @@ for (var type of largeTypes) {
 }
 
 for (var type of floatTypes) {
+  test(type.name + ' neg', function() {
+    testUnaryOp(type, 'neg', function(a) { return -a; });
+  });
   test(type.name + ' div', function() {
     testBinaryOp(type, 'div', function(a, b) { return a / b; });
   });
@@ -870,9 +876,6 @@ for (var type of floatTypes) {
 }
 
 for (var type of intTypes) {
-  test(type.name + ' neg', function() {
-    testUnaryOp(type, 'neg', function(a) { return -a; });
-  });
   test(type.name + ' not', function() {
     testUnaryOp(type, 'not', function(a) { return ~a; });
   });
@@ -881,8 +884,13 @@ for (var type of intTypes) {
       if (bits>>>0 >= type.laneSize * 8) return 0;
       return a << bits;
     }
-
     testShiftOp(type, 'shiftLeftByScalar', shift);
+  });
+}
+
+for (var type of signedIntTypes) {
+  test(type.name + ' neg', function() {
+    testUnaryOp(type, 'neg', function(a) { return -a; });
   });
   test(type.name + ' shiftRightArithmeticByScalar', function() {
     function shift(a, bits) {
@@ -890,7 +898,6 @@ for (var type of intTypes) {
         bits = type.laneSize * 8 - 1;
       return a >> bits;
     }
-
     testShiftOp(type, 'shiftRightArithmeticByScalar', shift);
   });
 }
@@ -905,12 +912,12 @@ for (var type of unsignedIntTypes) {
     }
     testShiftOp(type, 'shiftRightLogicalByScalar', shift);
   });
-}
-
-for (var type of smallUnsignedIntTypes) {testHorizontalSum
   test(type.name + ' horizontalSum', function() {
     testHorizontalSum(type);
   });
+}
+
+for (var type of smallUnsignedIntTypes) {testHorizontalSum
   test(type.name + ' absoluteDifference', function() {
     testBinaryOp(type, 'absoluteDifference', function(a, b) { return Math.abs(a - b); });
   });

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -221,6 +221,8 @@ var floatTypes = [float32x4];
 var intTypes = [int32x4, int16x8, int8x16,
                 uint32x4, uint16x8, uint8x16];
 
+var signedTypes = [float32x4, int32x4, int16x8, int8x16];
+
 var signedIntTypes = [int32x4, int16x8, int8x16];
 
 var unsignedIntTypes = [uint32x4, uint16x8, uint8x16];
@@ -848,10 +850,13 @@ for (var type of largeTypes) {
   });
 }
 
-for (var type of floatTypes) {
+for (var type of signedTypes) {
   test(type.name + ' neg', function() {
     testUnaryOp(type, 'neg', function(a) { return -a; });
   });
+}
+
+for (var type of floatTypes) {
   test(type.name + ' div', function() {
     testBinaryOp(type, 'div', function(a, b) { return a / b; });
   });
@@ -889,9 +894,6 @@ for (var type of intTypes) {
 }
 
 for (var type of signedIntTypes) {
-  test(type.name + ' neg', function() {
-    testUnaryOp(type, 'neg', function(a) { return -a; });
-  });
   test(type.name + ' shiftRightArithmeticByScalar', function() {
     function shift(a, bits) {
       if (bits>>>0 >= type.laneSize * 8)
@@ -917,7 +919,7 @@ for (var type of unsignedIntTypes) {
   });
 }
 
-for (var type of smallUnsignedIntTypes) {testHorizontalSum
+for (var type of smallUnsignedIntTypes) {
   test(type.name + ' absoluteDifference', function() {
     testBinaryOp(type, 'absoluteDifference', function(a, b) { return Math.abs(a - b); });
   });


### PR DESCRIPTION
The polyfill was iterating over all the source lanes for widenedAbsoluteDifference, which isn't necessary.

The tests weren't testing all the methods they were supposed to. horizontalSum is defined for all unsigned int types.