### PR TITLE
Fixing tests that fail in strict mode due to variable scope.

### DIFF
--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -403,7 +403,7 @@ function testCheck(type) {
 
 function testReplaceLane(type) {
   equal('function', typeof type.fn.replaceLane);
-  a = createTestValue(type);
+  var a = createTestValue(type);
   for (var v of type.interestingValues) {
     var expected = simdConvert(type, v);
     for (var i = 0; i < type.lanes; i++) {
@@ -1057,7 +1057,7 @@ function equalInt32x4(a, b) {
 
 test('Float32x4 Int32x4 round trip', function() {
   // NaNs should stay unmodified across bit conversions
-  m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
+  var m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
   var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
   // NaNs may be canonicalized, so these tests may fail in some implementations.
   equalInt32x4(m, m2);


### PR DESCRIPTION
Test262 framework runs tests in strict mode as well as non strict mode, fixing scope so tests pass in strict mode. 