### PR TITLE
Consider non floating-point arguments to ToFloat32 in the spec text

### DIFF
--- a/tc39/spec.html
+++ b/tc39/spec.html
@@ -797,8 +797,10 @@ Returns the absolute value of x; the result has the same magnitude as x but has 
 </emu-clause>
 
 <emu-clause id="fround" aoid="ToFloat32">
-<h1>ToFloat32( x )</h1>
+<h1>ToFloat32( argument )</h1>
 <emu-alg>
+1. Let x be ToNumber(argument).
+1. ReturnIfAbrupt(x).
 1. If x is NaN, return NaN.
 1. If x is one of +0, −0, +∞, −∞, return x.
 1. Let x32 be the result of converting x to a value in IEEE 754-2008 binary32 format using roundTiesToEven.


### PR DESCRIPTION
Unless I am missing something, the spec text says that the [[Cast]] operation for float32 is ToFloat32, as per http://tc39.github.io/ecmascript_simd/#simd-descriptors . However, this links to http://tc39.github.io/ecmascript_simd/#fround , which seems to make the hypothesis that x is already a Number. However, for the other [[Cast]], e.g. for Int32x4, the conversion operation is ToInt32 ( http://www.ecma-international.org/ecma-262/6.0/index.html#sec-toint32 ), which performs ToNumber first.

It seems more natural that the behavior for Float32 be the same as for Int32, that is to convert the input into a number. What do you think?