### PR TITLE
Editorial fixes

### DIFF
--- a/tc39/spec.html
+++ b/tc39/spec.html
@@ -1226,7 +1226,7 @@ This operation is only defined on <a href="#simd-integer-type">integer</a> and <
 <h1>_SIMD_Constructor.lessThanOrEqual(a, b)</h1>
 <p>This definition uses `<=` to refer to the abstract operation defined by <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-relational-comparison">ES2015 7.2.11 (Abstract Relational Comparison)</a>.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-alg>
 1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor or _b_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a TypeError exception.
@@ -1374,7 +1374,7 @@ This operation is only defined on <a href="#simd-integer-type">integer</a> SIMD 
 
 <emu-clause id="simd-shift-right-by-scalar">
 <h1>_SIMD_Constructor.shiftRightByScalar( a, bits )</h1>
-This operation is only defined on <a href="#simd-integer-type">integer</a> SIMD types. 
+This operation is only defined on <a href="#simd-integer-type">integer</a> SIMD types.
 
 On <a href="#simd-unsigned-integer-type">unsigned</a> SIMD types, the following definition is used. This definition uses `>>>` to refer to the abstract operation defined by <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-unsigned-right-shift-operator">ES2015 12.8.5 (The Unsigned Right Shift Operator ( >>> ))</a>.
 <emu-alg>
@@ -1420,7 +1420,7 @@ On <a href="#simd-signed-integer-type">signed</a> SIMD types, the following defi
 <h1>_SIMD_Constructor.store( tarray, index, simd )</h1>
 <p>This is defined when _SIMD_Descriptor has a [[SerializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-alg>
 1. Return SIMDStoreInTypedArray(_tarray_, _index_, _SIMD_Descriptor, _simd_).
@@ -1431,7 +1431,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.store1( tarray, index, simd )</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4, and when _SIMD_Descriptor has a [[SerializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-alg>
 1. Return SIMDStoreInTypedArray(_tarray_, _index_, _SIMD_Descriptor, _simd_, 1).
@@ -1442,7 +1442,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.store2( tarray, index, simd )</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4, and when _SIMD_Descriptor has a [[SerializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 <emu-alg>
 1. Return SIMDStoreInTypedArray(_tarray_, _index_, _SIMD_Descriptor, _simd_, 2).
 </emu-alg>
@@ -1452,7 +1452,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.store3( tarray, index, simd )</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4, and when _SIMD_Descriptor has a [[SerializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 <emu-alg>
 1. Return SIMDStoreInTypedArray(_tarray_, _index_, _SIMD_Descriptor, _simd_, 3).
 </emu-alg>
@@ -1462,7 +1462,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.load( tarray, index )</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor has a [[DeserializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-note>`load` takes a TypedArray of any element type as an argument. One way to use it is to pass in a `Uint8Array` regardless of SIMD type, which is useful because it allows the compiler to eliminate the shift in going from the index to the pointer offset. Other options considered were to use an ArrayBuffer (but this is not idiomatic, to take an ArrayBuffer directly as an argument to read off of) or a DataView (but DataViews don't tend to expose platform-dependent endianness, which is important here, and they tend to use methods on `DataView.prototype`, which are harder to optimize in an asm.js context).</emu-note>
 <emu-alg>
@@ -1474,7 +1474,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.load1(tarray, index)</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4 and _SIMD_Descriptor has a [[DeserializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 <emu-alg>
 1. Return SIMDLoadFromTypedArray(_tarray_, _index_, _SIMD_Descriptor, 1).
 </emu-alg>
@@ -1484,7 +1484,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.load2(tarray, index)</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4 and _SIMD_Descriptor has a [[DeserializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 <emu-alg>
 1. Return SIMDLoadFromTypedArray(_tarray_, _index_, _SIMD_Descriptor, 2).
 </emu-alg>
@@ -1494,7 +1494,7 @@ This operation exists only on integer and floating point SIMD types.
 <h1>_SIMD_Constructor.load3(tarray, index)</h1>
 <p>This function is defined only on SIMD types where _SIMD_Descriptor.[[VectorLength]] = 4 and _SIMD_Descriptor has a [[DeserializeElement]] field.</p>
 
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 <emu-alg>
 1. Return SIMDLoadFromTypedArray(_tarray_, _index_, _SIMD_Descriptor, 3).
 </emu-alg>
@@ -1516,7 +1516,7 @@ In this definition, _TIMD_ is not _SIMD_, _TIMD_ ranges over all SIMD types for 
 <emu-alg>
 1. If _value_.[[SIMDTypeDescriptor]] is not _TIMD_Descriptor, throw a TypeError exception.
 1. Let _list_ be a copy of _value_.[[SIMDElements]].
-1. If _SIMD_ is an integer type and _TIMD_ is a floating point type, 
+1. If _SIMD_ is an integer type and _TIMD_ is a floating point type,
   1. For _element_ in _list_,
     1. if _element_ is *NaN* or _element_ `>` _SIMD_Descriptor.[[ElementMax]] or _element_ `<` _SIMD_Descriptor.[[ElementMin]], throw a *RangeError* exception.
 1. Return SIMDCreate(_SIMD_Descriptor, _list_).
@@ -1528,7 +1528,7 @@ This definition uses `<` and `>` to refer to the abstract operation defined by <
 
 <emu-clause id="swizzle">
 <h1>_SIMD_Constructor.swizzle( a, ...lanes )</h1>
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-alg>
 1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
@@ -1548,7 +1548,7 @@ The `length` property of `_SIMD_.swizzle` is 1 + _SIMD_Descriptor.[[VectorLength
 
 <emu-clause id="shuffle">
 <h1>_SIMD_Constructor.shuffle( a, b, ...lanes )</h1>
-This operation exists only on integer and floating point SIMD types.
+This operation exists only on <a href="#simd-integer-type">integer</a> and <a href="#simd-floating-point-type">floating point</a> SIMD types.
 
 <emu-alg>
 1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, or if _b_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
@@ -1759,69 +1759,69 @@ In the internal algorithms in this section, preceding the first step, if _isLitt
 <tr>
 <td>Int16x8</td>
 <td><a href="#simd-signed-integer-type">signed integer</a></td>
-<td>8</li>
-<td>2</li>
-<td>ToInt16</li>
+<td>8</td>
+<td>2</td>
+<td>ToInt16</td>
 <td>SerializeInt(Int16x8Descriptor)</td>
 <td>DeserializeInt(Int16x8Descriptor)</td>
-<td>2<sup>15</sup>-1</li>
-<td>-2<sup>15</sup></li>
+<td>2<sup>15</sup>-1</td>
+<td>-2<sup>15</sup></td>
 </tr>
 
 <tr>
 <td>Int8x16</td>
 <td><a href="#simd-signed-integer-type">signed integer</a></td>
-<td>16</li>
-<td>1</li>
-<td>ToInt8</li>
+<td>16</td>
+<td>1</td>
+<td>ToInt8</td>
 <td>SerializeInt(Int8x16Descriptor)</td>
 <td>DeserializeInt(Int8x16Descriptor)</td>
-<td>127</li>
-<td>-128</li>
+<td>127</td>
+<td>-128</td>
 </tr>
 
 <tr>
 <td>Uint32x4</td>
 <td><a href="#simd-unsigned-integer-type">unsigned integer</a></td>
-<td>4</li>
-<td>4</li>
-<td>ToUint32</li>
+<td>4</td>
+<td>4</td>
+<td>ToUint32</td>
 <td>SerializeInt(Uint32x4Descriptor)</td>
 <td>DeserializeInt(Uint32x4Descriptor)</td>
-<td>2<sup>32</sup>-1</li>
-<td>0</li>
+<td>2<sup>32</sup>-1</td>
+<td>0</td>
 </tr>
 
 <tr>
 <td>Uint16x8</td>
 <td><a href="#simd-unsigned-integer-type">unsigned integer</a></td>
-<td>8</li>
-<td>2</li>
-<td>ToUint16</li>
+<td>8</td>
+<td>2</td>
+<td>ToUint16</td>
 <td>SerializeInt(Uint16x8Descriptor)</td>
 <td>DeserializeInt(Uint16x8Descriptor)</td>
-<td>2<sup>16</sup>-1</li>
-<td>0</li>
+<td>2<sup>16</sup>-1</td>
+<td>0</td>
 </tr>
 
 <tr>
 <td>Uint8x16</td>
 <td><a href="#simd-unsigned-integer-type">unsigned integer</a></td>
-<td>16</li>
-<td>1</li>
-<td>ToUint8</li>
+<td>16</td>
+<td>1</td>
+<td>ToUint8</td>
 <td>SerializeInt(Uint8x16Descriptor)</td>
 <td>DeserializeInt(Uint8x16Descriptor)</td>
-<td>255</li>
-<td>0</li>
+<td>255</td>
+<td>0</td>
 </tr>
 
 <tr>
 <td>Bool32x4</td>
 <td><a href="#simd-boolean-type">boolean</a></td>
-<td>4</li>
+<td>4</td>
 <td></td>
-<td>ToBoolean</li>
+<td>ToBoolean</td>
 <td></td>
 <td></td>
 <td></td>
@@ -1831,9 +1831,9 @@ In the internal algorithms in this section, preceding the first step, if _isLitt
 <tr>
 <td>Bool16x8</td>
 <td><a href="#simd-boolean-type">boolean</a></td>
-<td>8</li>
+<td>8</td>
 <td></td>
-<td>ToBoolean</li>
+<td>ToBoolean</td>
 <td></td>
 <td></td>
 <td></td>
@@ -1843,9 +1843,9 @@ In the internal algorithms in this section, preceding the first step, if _isLitt
 <tr>
 <td>Bool8x16</td>
 <td><a href="#simd-boolean-type">boolean</a></td>
-<td>16</li>
+<td>16</td>
 <td></td>
-<td>ToBoolean</li>
+<td>ToBoolean</td>
 <td></td>
 <td></td>
 <td></td>


### PR DESCRIPTION
* Add links to the integer and floating point types for all functions.
* Fix the type descriptor table to use a closing `</td>` instead of `</li>`.