### PR TITLE
Give shift operators masking shift count semantics.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1186,8 +1186,7 @@ var simdFns = {
   shiftLeftByScalar:
     function(type) {
       return function(a, bits) {
-        if (bits>>>0 >= type.laneSize * 8)
-          return type.fn.splat(0);
+        bits &= type.laneSize * 8 - 1;
         return simdShiftOp(type, binaryShiftLeft, a, bits);
       }
     },
@@ -1196,14 +1195,12 @@ var simdFns = {
     function(type) {
       if (type.unsigned) {
         return function(a, bits) {
-          if (bits>>>0 >= type.laneSize * 8)
-            return type.fn.splat(0);
+          bits &= type.laneSize * 8 - 1;
           return simdShiftOp(type, binaryShiftRightLogical, a, bits);
         }
       } else {
         return function(a, bits) {
-          if (bits>>>0 >= type.laneSize * 8)
-            bits = type.laneSize * 8 - 1;
+          bits &= type.laneSize * 8 - 1;
           return simdShiftOp(type, binaryShiftRightArithmetic, a, bits);
         }
       }

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -939,7 +939,7 @@ simdTypes.filter(isIntType).forEach(function(type) {
   });
   test(type.name + ' shiftLeftByScalar', function() {
     function shift(a, bits) {
-      if (bits>>>0 >= type.laneSize * 8) return 0;
+      bits &= type.laneSize * 8 - 1;
       return a << bits;
     }
     testShiftOp(type, 'shiftLeftByScalar', shift);
@@ -949,8 +949,7 @@ simdTypes.filter(isIntType).forEach(function(type) {
 simdTypes.filter(isSignedIntType).forEach(function(type) {
   test(type.name + ' shiftRightByScalar', function() {
     function shift(a, bits) {
-      if (bits>>>0 >= type.laneSize * 8)
-        bits = type.laneSize * 8 - 1;
+      bits &= type.laneSize * 8 - 1;
       return a >> bits;
     }
     testShiftOp(type, 'shiftRightByScalar', shift);
@@ -960,7 +959,7 @@ simdTypes.filter(isSignedIntType).forEach(function(type) {
 simdTypes.filter(isUnsignedIntType).forEach(function(type) {
   test(type.name + ' shiftRightByScalar', function() {
     function shift(a, bits) {
-      if (bits>>>0 >= type.laneSize * 8) return 0;
+      bits &= type.laneSize * 8 - 1;
       if (type.laneMask)
         a &= type.laneMask;
       return a >>> bits;


### PR DESCRIPTION
After pull  #320, shift counts are reduced modulo the lane size rather than
saturating.