### PR TITLE
Throw a RangeError when fromFloat32x4 sees a NaN.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -160,7 +160,7 @@ function simdFrom(toType, fromType, a) {
   for (var i = 0; i < fromType.lanes; i++) {
     var v = fromType.fn.extractLane(a, i);
     if (toType.minVal !== undefined &&
-        (v < toType.minVal || v > toType.maxVal)) {
+        !(toType.minVal <= v && v <= toType.maxVal)) {
       throw new RangeError("Can't convert value");
     }
     lanes[i] = v;

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -496,7 +496,7 @@ function testFrom(toType, fromType, name) {
     var fromValue = createSplatValue(fromType, v);
     v = simdConvert(fromType, v);
     if (toType.minVal !== undefined &&
-        (v < toType.minVal || v > toType.maxVal)) {
+        !(toType.minVal <= v && v <= toType.maxVal)) {
       throws(function() { toType.fn[name](fromValue) });
     } else {
       v = simdConvert(toType, v);


### PR DESCRIPTION
This brings the polyfill and tests in line with the text of the specification.