### PR TITLE
Don't pass SIMD values to equal().

### DIFF
--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -393,10 +393,12 @@ function testCheck(type) {
   // Other SIMD types shouldn't check for this type.
   var a = type.fn();
   for (var otherType of simdTypes) {
-    if (otherType === type)
-      equal(a, type.fn.check(a));
-    else
+    if (otherType === type) {
+      var result = type.fn.check(a);
+      checkValue(type, result, function(index) { return type.fn.extractLane(a, index); });
+    } else {
       throws(function() { otherType.check(a); });
+    }
   }
   // Neither should other types.
   for (var x of [ {}, "", 0, 1, true, false, undefined, null, NaN, Infinity]) {


### PR DESCRIPTION
This function is implemented in terms of 'a == b', which causes two problems:

1. It doesn't do the right thing for Float32x4(NaN, NaN, NaN, NaN), and
2. It depends on value semantics for '==' to work.

Value semantics should only be tested by the testValueSemantics() function.