### PR TITLE
Truncate before range checking in float to int conversion.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -158,7 +158,7 @@ function simdReplaceLane(type, a, i, s) {
 function simdFrom(toType, fromType, a) {
   a = fromType.fn.check(a);
   for (var i = 0; i < fromType.lanes; i++) {
-    var v = fromType.fn.extractLane(a, i);
+    var v = Math.trunc(fromType.fn.extractLane(a, i));
     if (toType.minVal !== undefined &&
         !(toType.minVal <= v && v <= toType.maxVal)) {
       throw new RangeError("Can't convert value");

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -75,7 +75,7 @@ var float32x4 = {
   numerical: true,
   lanes: 4,
   laneSize: 4,
-  interestingValues: [0, -0, 1, -1, 1.414, 0x7F, -0x80, -0x8000, -0x80000000, 0x7FFF, 0x7FFFFFFF, Infinity, -Infinity, NaN],
+  interestingValues: [0, -0, 1, -1, 0.9, -0.9, 1.414, 0x7F, -0x80, -0x8000, -0x80000000, 0x7FFF, 0x7FFFFFFF, Infinity, -Infinity, NaN],
   view: Float32Array,
   buffer: _f32x4,
   mulFn: binaryMul,
@@ -494,7 +494,7 @@ function testFrom(toType, fromType, name) {
   equal('function', typeof toType.fn[name]);
   for (var v of fromType.interestingValues) {
     var fromValue = createSplatValue(fromType, v);
-    v = simdConvert(fromType, v);
+    v = Math.trunc(simdConvert(fromType, v));
     if (toType.minVal !== undefined &&
         !(toType.minVal <= v && v <= toType.maxVal)) {
       throws(function() { toType.fn[name](fromValue) });

--- a/tc39/spec.html
+++ b/tc39/spec.html
@@ -1514,7 +1514,9 @@ In this definition, _TIMD_ is not _SIMD_, _TIMD_ ranges over all SIMD types for 
 1. Let _list_ be a copy of _value_.[[SIMDElements]].
 1. If _SIMD_ is an integer type and _TIMD_ is a floating point type,
   1. For _element_ in _list_,
-    1. if _element_ is *NaN* or _element_ `>` _SIMD_Descriptor.[[ElementMax]] or _element_ `<` _SIMD_Descriptor.[[ElementMin]], throw a *RangeError* exception.
+    1. If _element_ is *NaN*, throw a *RangeError* exception.
+    1. Let _intElement_ be ToInteger(_element_).
+    1. If _intElement_ `>` _SIMD_Descriptor.[[ElementMax]] or _intElement_ `<` _SIMD_Descriptor.[[ElementMin]], throw a *RangeError* exception.
 1. Return SIMDCreate(_SIMD_Descriptor, _list_).
 </emu-alg>
 <emu-note>


### PR DESCRIPTION
Implement the range checking semantics from #315 in the polyfill and tests.

When converting a floating point value to an integer value, truncate the
floating point value before checking if it is out of range. The effect is that
negative numbers > -1.0 are converted to 0 by Uint32x4.fromFloat32x4() rather
than throwing a RangeError.