### PR TITLE
Add a `thisSIMDValue()` abstract operation.

### DIFF
--- a/tc39/spec.html
+++ b/tc39/spec.html
@@ -1573,6 +1573,18 @@ The `length` property of `_SIMD_.shuffle` is 2 + _SIMD_Descriptor.[[VectorLength
 <emu-clause id="simd-proto">
 <h1>The _SIMD_Constructor.prototype</h1>
 
+<emu-clause id="this-simd-value" aoid="thisSIMDValue">
+<h1>thisSIMDValue( value )</h1>
+The abstract operation thisSIMDValue(_value_) performs the following steps:
+<emu-alg>
+1. If Type(_value_) is a SIMD type, return _value_.
+1. If Type(_value_) is Object and value has a [[SIMDData]] internal slot, then
+  1. Assert: _value_'s [[SIMDData]] internal slot is a SIMD value.
+  1. Return the value of _value_'s [[SIMDData]] internal slot.
+1. Throw a *TypeError* exception.
+</emu-alg>
+</emu-clause>
+
 <emu-clause id="simd-proto-constructor">
 <h1>_SIMD_Constructor.prototype.constructor</h1>
 The initial value of _SIMD_Constructor.prototype.constructor is the intrinsic object %_SIMD_Constructor%
@@ -1581,9 +1593,9 @@ The initial value of _SIMD_Constructor.prototype.constructor is the intrinsic ob
 <emu-clause id="simd-prototype-valueof">
 <h1>_SIMD_Constructor.prototype.valueOf()</h1>
 <emu-alg>
-1. If *this* does not have a [[SIMDWrapperData]] internal slot, throw a *TypeError* exception.
-1. If *this*.[[SIMDWrapperData]].[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
-1. Return *this*.[[SIMDWrapperData]].
+1. Let _simd_ be thisSIMDValue(*this* value).
+1. If _simd_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
+1. Return _simd_.
 </emu-alg>
 </emu-clause>
 
@@ -1595,11 +1607,11 @@ An ECMAScript implementation that includes the ECMA-402 Internationalization API
 
 The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
 <emu-alg>
-1. If *this* does not have a [[SIMDWrapperData]] internal slot, throw a *TypeError* exception.
-1. If *this*.[[SIMDWrapperData]].[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
+1. Let _simd_ be thisSIMDValue(*this* value).
+1. If _simd_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
 1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
 1. Let _list_ be an empty List
-1. For each element _element_ in _argument_.[[SIMDElements]],
+1. For each element _element_ in _simd_.[[SIMDElements]],
   1. Let _R_ be ToString(Invoke(_element_, "toLocaleString")).
   1. ReturnIfAbrupt(_R_).
   1. Append _R_ to _list_.
@@ -1613,9 +1625,9 @@ The meanings of the optional parameters to this method are defined in the ECMA-4
 <emu-clause id="simd-prototype-tostring">
 <h1>_SIMD_Constructor.prototype.toString()</h1>
 <emu-alg>
-1. If *this* does not have a [[SIMDWrapperData]] internal slot, throw a *TypeError* exception.
-1. If *this*.[[SIMDWrapperData]].[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
-1. Return ToString(*this*.[[SIMDWrapperData]]).
+1. Let _simd_ be thisSIMDValue(*this* value).
+1. If _simd_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
+1. Return ToString(_simd_).
 </emu-alg>
 <emu-note>This definition depends on the primitive _SIMD_Type's behavior under ToString. Alternatively, _SIMD_Type could have ToString defined by calling ToObject and then reaching this method (or whatever the user overrides it with), in which case the current definition in ToString would be brought down here.</emu-note>
 </emu-clause>
@@ -1631,21 +1643,18 @@ This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false
 <emu-clause id="simd-to-primitive">
 <h1>_SIMD_Constructor.prototype [ @@toPrimitive ] ( hint )</h1>
 <emu-note>
-This function is called by ECMAScript language operators to convert a Symbol object to a primitive value. The allowed values for hint are `"default"`, `"number"`, and `"string"`.
+This function is called by ECMAScript language operators to convert a _SIMD_Constructor object to a primitive value. The allowed values for hint are `"default"`, `"number"`, and `"string"`.
 </emu-note>
 
 When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:
 
 <emu-alg>
-1. Let _s_ be the *this* value.
-1. If Type(_s_) is a SIMD type, return _s_.
-1. If Type(_s_) is not `Object`, throw a *TypeError* exception.
-1. If _s_ does not have a [[SIMDWrapperData]] internal slot, throw a *TypeError* exception.
-1. If _s_.[[SIMDWrapperData]].[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
-1. Return the value of _s_’s [[SIMDWrapperData]] internal slot.
+1. Let _simd_ be thisSIMDValue(*this* value).
+1. If _simd_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a *TypeError* exception.
+1. Return _simd_.
 </emu-alg>
 
-<p>The value of the `name` property of this function is `"[Symbol.toPrimitive]"`.</p>
+<p>The value of the `name` property of this function is `"[SIMD.`_SIMD_`.toPrimitive]"`, e.g., `"[SIMD.Int32x4.toPrimitive]"`.</p>
 
 This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
 


### PR DESCRIPTION
Modelled after the existing `thisNumberValue()`, `thisBooleanValue()`, ...
abstract operations, accept either a primitive SIMD value or a SIMD object
wrapping a value. In either case, return the primitive SIMD value.

Use this function in the SIMD constructor prototype methods such that they
accept both SIMD objects and primitive values as callees.

- Use [[SIMDData]] everywhere instead of [[SIMDWrapperData]].

- Fix a few pasto's in verbiage copied from the `Symbol` specification.

This fixes #338.