### PR TITLE
Remove the minNum and maxNum functions.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -84,18 +84,6 @@ function isTypedArray(o) {
          (o instanceof Float64Array);
 }
 
-function minNum(x, y) {
-  return x != x ? y :
-         y != y ? x :
-         Math.min(x, y);
-}
-
-function maxNum(x, y) {
-  return x != x ? y :
-         y != y ? x :
-         Math.max(x, y);
-}
-
 function clamp(a, min, max) {
   if (a < min)
     return min;
@@ -628,7 +616,7 @@ var float32x4 = {
   mulFn: binaryMul,
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
-        "add", "sub", "mul", "div", "neg", "abs", "min", "max", "minNum", "maxNum",
+        "add", "sub", "mul", "div", "neg", "abs", "min", "max",
         "reciprocalApproximation", "reciprocalSqrtApproximation", "sqrt",
         "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
 }
@@ -872,7 +860,7 @@ if (typeof simdPhase2 !== 'undefined') {
     mulFn: binaryMul,
     fns: ["check", "splat", "replaceLane", "select",
           "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
-          "add", "sub", "mul", "div", "neg", "abs", "min", "max", "minNum", "maxNum",
+          "add", "sub", "mul", "div", "neg", "abs", "min", "max",
           "reciprocalApproximation", "reciprocalSqrtApproximation", "sqrt",
           "load", "store"],
   }
@@ -1084,20 +1072,6 @@ var simdFns = {
     function(type) {
       return function(a, b) {
         return simdBinaryOp(type, Math.max, a, b);
-      }
-    },
-
-  minNum:
-    function(type) {
-      return function(a, b) {
-        return simdBinaryOp(type, minNum, a, b);
-      }
-    },
-
-  maxNum:
-    function(type) {
-      return function(a, b) {
-        return simdBinaryOp(type, maxNum, a, b);
       }
     },
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -18,18 +18,6 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-function minNum(x, y) {
-  return x != x ? y :
-         y != y ? x :
-         Math.min(x, y);
-}
-
-function maxNum(x, y) {
-  return x != x ? y :
-         y != y ? x :
-         Math.max(x, y);
-}
-
 function sameValue(x, y) {
   if (x == y)
     return x != 0 || y != 0 || (1/x == 1/y);
@@ -942,12 +930,6 @@ simdTypes.filter(isFloatType).forEach(function(type) {
   });
   test(type.name + ' max', function() {
     testBinaryOp(type, 'max', Math.max);
-  });
-  test(type.name + ' minNum', function() {
-    testBinaryOp(type, 'minNum', minNum);
-  });
-  test(type.name + ' maxNum', function() {
-    testBinaryOp(type, 'maxNum', maxNum);
   });
   test(type.name + ' sqrt', function() {
     testUnaryOp(type, 'sqrt', function(a) { return Math.sqrt(a); });

--- a/tc39/spec.html
+++ b/tc39/spec.html
@@ -841,30 +841,6 @@ Given two arguments, calls ToNumber on each of the arguments and returns the sma
 </ul>
 </emu-clause>
 
-<emu-clause id="max-num" aoid="MaxNum">
-<h1>MaxNum(n, m)</h1>
-<emu-alg>
-1. Assert Type(_n_) is Number and Type(_m_) is Number.
-1. If _n_ is *NaN*, return _m_.
-1. If _m_ is *NaN*, return _n_.
-1. Let _result_ be MathMax(_n_, _m_).
-1. ReturnIfAbrupt(_result_).
-1. Return _result_.
-</emu-alg>
-</emu-clause>
-
-<emu-clause id="min-num" aoid="MinNum">
-<h1>MinNum(n, m)</h1>
-<emu-alg>
-1. Assert Type(_n_) is Number and Type(_m_) is Number.
-1. If _n_ is *NaN*, return _m_.
-1. If _m_ is *NaN*, return _n_.
-1. Let _result_ be MathMin(_n_, _m_).
-1. ReturnIfAbrupt(_result_).
-1. Return _result_.
-</emu-alg>
-</emu-clause>
-
 <emu-clause id="reciprocal" aoid="ReciprocalApproximation">
 <h1>ReciprocalApproximation(n)</h1>
 Returns an implementation-dependent approximation to the reciprocal of _n_.
@@ -1076,28 +1052,6 @@ This property is defined only on floating point SIMD types.
 <emu-alg>
 1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor or _b_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a TypeError exception.
 1. Let _result_ be SIMDBinaryOp(_a_, _b_, MathMin).
-1. ReturnIfAbrupt(_result_).
-1. Return _result_.
-</emu-alg>
-</emu-clause>
-
-<emu-clause id="simd-max-num">
-<h1>_SIMD_Constructor.maxNum(a, b)</h1>
-This operation is only defined on <a href="#simd-floating-point-type">floating point</a> SIMD types.
-<emu-alg>
-1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor or _b_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a TypeError exception.
-1. Let _result_ be SIMDBinaryOp(_a_, _b_, MaxNum).
-1. ReturnIfAbrupt(_result_).
-1. Return _result_.
-</emu-alg>
-</emu-clause>
-
-<emu-clause id="simd-min-num">
-<h1>_SIMD_Constructor.minNum(a, b)</h1>
-This operation is only defined on <a href="#simd-floating-point-type">floating point</a> SIMD types.
-<emu-alg>
-1. If _a_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor or _b_.[[SIMDTypeDescriptor]] is not _SIMD_Descriptor, throw a TypeError exception.
-1. Let _result_ be SIMDBinaryOp(_a_, _b_, MinNum).
 1. ReturnIfAbrupt(_result_).
 1. Return _result_.
 </emu-alg>


### PR DESCRIPTION
See discussion in #341.

These two functions were added to correspond with the IEEE 754 functions of the
same name. However, since EcmaScript doesn't distinguish quiet and signaling
NaNs, it is non-trivial to achieve the exact same behavior as the IEEE
functions.

The SIMD.js min() and max() functions remain. They have the same behavior as
Math.min() and Math.max().